### PR TITLE
Fix compile error in r0gdb.c when using newer GCC versions

### DIFF
--- a/prosper0gdb/r0gdb.c
+++ b/prosper0gdb/r0gdb.c
@@ -963,7 +963,7 @@ static void instr_count_and_hang(uint64_t* regs)
         instrs_left--;
 }
 
-static int count_instrs(void(*fn)(), uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t entry, uint64_t jump, int instrs)
+static int count_instrs(void(*fn)(uint64_t, uint64_t, uint64_t), uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t entry, uint64_t jump, int instrs)
 {
     r0gdb_trace_reset();
     trace_prog = instr_count;


### PR DESCRIPTION
The default [C standard](https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Standards.html#Standards) that GCC 15.2.1 is using is `-std=gnu23` which doesn't allow the old empty function argument list to mean an unknown number of parameters. As the  function pointer is called with 3 parameters, it has been updated to list the argument types.

The error is below.
```
gcc -O0 -g -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -r -Wl,--unique='*' -ffunction-sections -fdata-sections  -DPS5KEK r0gdb.c r0run.o offsets.c -o prosper0gdb.o -fPIE -ffreestanding -fno-unwind-tables -fno-asynchronous-unwind-tables
r0gdb.c: In function ‘count_instrs’:
r0gdb.c:974:5: error: too many arguments to function ‘fn’; expected 0, have 3
  974 |     fn(arg1, arg2, arg3);
      |     ^~ ~~~~
make[1]: *** [Makefile:16: prosper0gdb.o] Error 1
```