### PR TITLE
uelf: harden syscall and crypto handling

### DIFF
--- a/ps5-kstuff/uelf/fakekeys.c
+++ b/ps5-kstuff/uelf/fakekeys.c
@@ -5,7 +5,8 @@
 extern struct
 {
     uint64_t bitmask;
-    char pad[24];
+    uint64_t ready_mask;
+    char pad[16];
     char key_data[63][32];
 } shared_area;
 
@@ -21,7 +22,9 @@ int register_fake_key(const char key_data[32])
     }
     while(!__atomic_compare_exchange_n(&shared_area.bitmask, &mask, mask1, 1, __ATOMIC_RELEASE, __ATOMIC_ACQUIRE));
     int key_idx = 63 - __builtin_clzll(mask ^ mask1);
+    uint64_t bit = 1ull << key_idx;
     memcpy(shared_area.key_data[key_idx], key_data, 32);
+    __atomic_fetch_or(&shared_area.ready_mask, bit, __ATOMIC_RELEASE);
     return key_idx;
 }
 
@@ -29,15 +32,17 @@ int unregister_fake_key(int key_id)
 {
     if(key_id < 0 || key_id >= 63)
         return 0;
+    uint64_t bit = 1ull << key_id;
     uint64_t mask, mask1;
-    mask = __atomic_load_n(&shared_area.bitmask, __ATOMIC_ACQUIRE);
+    mask = __atomic_load_n(&shared_area.ready_mask, __ATOMIC_ACQUIRE);
     do
     {
-        if(!(mask & (1ull << key_id)))
+        if(!(mask & bit))
             return 0;
-        mask1 = mask & ~(1ull << key_id);
+        mask1 = mask & ~bit;
     }
-    while(!__atomic_compare_exchange_n(&shared_area.bitmask, &mask, mask1, 1, __ATOMIC_RELEASE, __ATOMIC_ACQUIRE));
+    while(!__atomic_compare_exchange_n(&shared_area.ready_mask, &mask, mask1, 1, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE));
+    __atomic_fetch_and(&shared_area.bitmask, ~bit, __ATOMIC_RELEASE);
     return 1;
 }
 
@@ -45,8 +50,9 @@ int get_fake_key(int key_id, char key_data[32])
 {
     if(key_id < 0 || key_id >= 63)
         return 0;
-    uint64_t mask = __atomic_load_n(&shared_area.bitmask, __ATOMIC_ACQUIRE);
-    if(!(mask & (1ull << key_id)))
+    uint64_t bit = 1ull << key_id;
+    uint64_t mask = __atomic_load_n(&shared_area.ready_mask, __ATOMIC_ACQUIRE);
+    if(!(mask & bit))
         return 0;
     memcpy(key_data, shared_area.key_data[key_id], 32);
     return 1;

--- a/ps5-kstuff/uelf/fpkg.c
+++ b/ps5-kstuff/uelf/fpkg.c
@@ -195,6 +195,8 @@ int try_handle_fpkg_mailbox(uint64_t* regs, uint64_t lr)
                     uint32_t fake_resp[4] = {0, 0, IDX_TO_HANDLE(key1), IDX_TO_HANDLE(key2)};
                     copy_to_kernel(regs[RDX], fake_resp, sizeof(fake_resp));
                 }
+                else
+                    unregister_fake_key(key1);
             }
         }
     }

--- a/ps5-kstuff/uelf/fpkg.c
+++ b/ps5-kstuff/uelf/fpkg.c
@@ -106,7 +106,7 @@ static int handle_crypto_request(uint64_t* regs, uint64_t bytes_handled)
     int total_status = 0;
     uint64_t new_bytes_handled = 0;
 
-    uint64_t start = (fwver >= 0x800) ? regs[RBX] : regs[R14];
+    uint64_t start = (FWVER >= 0x800) ? regs[RBX] : regs[R14];
 
     for (uint64_t msg = start; msg && !total_status; msg = kpeek64(msg + 320))
     {
@@ -142,7 +142,7 @@ static int handle_crypto_request(uint64_t* regs, uint64_t bytes_handled)
             total_status = -1;
         }
 
-        crypto_request_emulated(regs, (fwver >= 0x800) ? regs[RBX] : regs[R14], total_status);
+        crypto_request_emulated(regs, (FWVER >= 0x800) ? regs[RBX] : regs[R14], total_status);
 
         uint64_t end_time = rdtsc();
         /*log_word(0x1234);

--- a/ps5-kstuff/uelf/fpkg.c
+++ b/ps5-kstuff/uelf/fpkg.c
@@ -18,17 +18,19 @@ extern char doreti_iret[];
 #define IDX_TO_HANDLE(x) (0x13374100 | ((uint8_t)((x)+1)))
 #define HANDLE_TO_IDX(x) ((((x) & 0xffffff00) == 0x13374100 ? ((int)(uint8_t)(x)) : (int)0) - 1)
 
-static void crypto_request_emulated(uint64_t* regs, uint64_t msg, uint32_t status)
+static int crypto_request_emulated(uint64_t* regs, uint64_t msg, uint32_t status)
 {
     uint64_t frame[7] = {
         (uint64_t)doreti_iret,
         MKTRAP(TRAP_FPKG, 1), 0, 0, 0, 0,
         0
     };
-    push_stack(regs, frame, sizeof(frame));
+    if(push_stack_checked(regs, frame, sizeof(frame)))
+        return 0;
     regs[RIP] = (uint64_t)crypt_message_resolve;
     regs[RDI] = msg;
     regs[RSI] = status;
+    return 1;
 }
 
 static int handle_crypto_message(uint64_t* regs, uint64_t msg, uint64_t bytes_cap, uint64_t* bytes_handled)
@@ -50,11 +52,11 @@ static int handle_crypto_message(uint64_t* regs, uint64_t msg, uint64_t bytes_ca
         uint8_t hash[32] = {0};
         *bytes_handled += msg_data[1];
         if(bytes_cap < *bytes_handled && pfs_hmac_virtual(hash, key, msg_data[2], msg_data[1]))
-		 
-										   
             return -1;
-		 
-        copy_to_kernel(msg+32, hash, 32);
+        if(copy_to_kernel(msg+32, hash, 32))
+        {
+            return -1;
+        }
         return 0;
     }
     else if((msg_data[0] & 0x7ffff7ff) == 0x2108000) // AES-XTS decrypt/encrypt with key handle
@@ -107,7 +109,6 @@ static int handle_crypto_request(uint64_t* regs, uint64_t bytes_handled)
     uint64_t new_bytes_handled = 0;
 
     uint64_t start = (FWVER >= 0x800) ? regs[RBX] : regs[R14];
-
     for (uint64_t msg = start; msg && !total_status; msg = kpeek64(msg + 320))
     {
         int status = handle_crypto_message(regs, msg, bytes_handled, &new_bytes_handled);
@@ -118,7 +119,11 @@ static int handle_crypto_request(uint64_t* regs, uint64_t bytes_handled)
                 MKTRAP(TRAP_FPKG, 2), 0, 0, 0, 0,
                 new_bytes_handled,
             };
-            push_stack(regs, frame, sizeof(frame));
+            if(push_stack_checked(regs, frame, sizeof(frame)))
+            {
+                total_status = -1;
+                break;
+            }
             regs[RIP] = (uint64_t)doreti_iret;
             return 1;
         }
@@ -142,7 +147,8 @@ static int handle_crypto_request(uint64_t* regs, uint64_t bytes_handled)
             total_status = -1;
         }
 
-        crypto_request_emulated(regs, (FWVER >= 0x800) ? regs[RBX] : regs[R14], total_status);
+        if(!crypto_request_emulated(regs, (FWVER >= 0x800) ? regs[RBX] : regs[R14], total_status))
+            return 0;
 
         uint64_t end_time = rdtsc();
         /*log_word(0x1234);
@@ -173,7 +179,8 @@ int try_handle_fpkg_mailbox(uint64_t* regs, uint64_t lr)
     if(lr == (uint64_t)sceSblServiceMailbox_lr_verifySuperBlock)
     {
         uint64_t req[8];
-        copy_from_kernel(req, regs[RDX], 64);
+        if(copy_from_kernel(req, regs[RDX], 64))
+            return 0;
         uint64_t p_eekpfs = 0;
         memcpy(&p_eekpfs, DMEM+req[2]+32, 8);
         uint8_t eekpfs[256] = {0};
@@ -189,11 +196,16 @@ int try_handle_fpkg_mailbox(uint64_t* regs, uint64_t lr)
                 int key2 = register_fake_key(sk);
                 if(key2 >= 0)
                 {
+                    uint32_t fake_resp[4] = {0, 0, IDX_TO_HANDLE(key1), IDX_TO_HANDLE(key2)};
+                    if(copy_to_kernel(regs[RDX], fake_resp, sizeof(fake_resp)))
+                    {
+                        unregister_fake_key(key2);
+                        unregister_fake_key(key1);
+                        return 0;
+                    }
                     regs[RIP] = lr;
                     regs[RAX] = 0;
                     regs[RSP] += 8;
-                    uint32_t fake_resp[4] = {0, 0, IDX_TO_HANDLE(key1), IDX_TO_HANDLE(key2)};
-                    copy_to_kernel(regs[RDX], fake_resp, sizeof(fake_resp));
                 }
                 else
                     unregister_fake_key(key1);
@@ -203,13 +215,17 @@ int try_handle_fpkg_mailbox(uint64_t* regs, uint64_t lr)
     else if(lr == (uint64_t)sceSblServiceMailbox_lr_sceSblPfsClearKey_1
          || lr == (uint64_t)sceSblServiceMailbox_lr_sceSblPfsClearKey_2)
     {
-        uint32_t handle = kpeek64(regs[RDX]+8);
+        uint32_t handle;
+        if(copy_from_kernel(&handle, regs[RDX]+8, sizeof(handle)))
+            return 0;
 
         int key = HANDLE_TO_IDX(handle);
-        if(key >= 0 && unregister_fake_key(key))
+        if(key >= 0)
         {
-            copy_to_kernel(regs[RDX], (const uint64_t[16]){}, 16);
-
+            if(copy_to_kernel(regs[RDX], (const uint64_t[16]){}, 16))
+                return 0;
+            if(!unregister_fake_key(key))
+                return 0;
             regs[RIP] = lr;
             regs[RAX] = 0;
             regs[RSP] += 8;
@@ -249,7 +265,8 @@ void handle_fpkg_trap(uint64_t* regs, uint32_t trapno)
     if(trapno == 1)
     {
         uint64_t frame[12];
-        pop_stack(regs, frame, sizeof(frame));
+        if(pop_stack_checked(regs, frame, sizeof(frame)))
+            return;
         regs[RBX] = frame[7];
         regs[R14] = frame[8];
         regs[R15] = frame[9];
@@ -260,7 +277,8 @@ void handle_fpkg_trap(uint64_t* regs, uint32_t trapno)
     else if(trapno == 2)
     {
         uint64_t frame[6];
-        pop_stack(regs, frame, sizeof(frame));
+        if(pop_stack_checked(regs, frame, sizeof(frame)))
+            return;
         regs[RIP] = (uint64_t)sceSblServiceCryptAsync_deref_singleton;
         handle_crypto_request(regs, frame[5]);
     }

--- a/ps5-kstuff/uelf/fpu.c
+++ b/ps5-kstuff/uelf/fpu.c
@@ -3,20 +3,37 @@
 __attribute__((aligned(64))) static char xsave_area[4096]; //is this enough?
 static uint32_t xsave_eax, xsave_edx;
 static uint64_t saved_cr0;
+static uint32_t fpu_depth;
+static uint32_t fpu_state_saved;
 
-void uelf_fpu_enter(void)
+int uelf_fpu_enter(void)
 {
-    saved_cr0 = read_cr0();
-    write_cr0(saved_cr0 & -9); //clear CR0.TS
+    if(fpu_depth++)
+        return 0;
+    fpu_state_saved = 0;
+    if(read_cr0_checked(&saved_cr0) || write_cr0_checked(saved_cr0 & -9)) //clear CR0.TS
+    {
+        fpu_depth = 0;
+        return 1;
+    }
     asm volatile("xgetbv":"=d"(xsave_edx),"=a"(xsave_eax):"c"(0));
     asm volatile("xsave %0":"=m"(xsave_area):"a"(xsave_eax),"d"(xsave_edx));
     asm volatile("finit");
     uint32_t mxcsr = 0x1f80;
     asm volatile("ldmxcsr %0"::"m"(mxcsr));
+    fpu_state_saved = 1;
+    return 0;
 }
 
 void uelf_fpu_exit(void)
 {
+    if(!fpu_depth)
+        return;
+    if(--fpu_depth)
+        return;
+    if(!fpu_state_saved)
+        return;
     asm volatile("xrstor %0"::"m"(xsave_area),"a"(xsave_eax),"d"(xsave_edx));
-    write_cr0(saved_cr0);
+    write_cr0_checked(saved_cr0);
+    fpu_state_saved = 0;
 }

--- a/ps5-kstuff/uelf/fpu.h
+++ b/ps5-kstuff/uelf/fpu.h
@@ -1,4 +1,4 @@
 #pragma once
 
-void uelf_fpu_enter(void);
+int uelf_fpu_enter(void);
 void uelf_fpu_exit(void);

--- a/ps5-kstuff/uelf/fself.c
+++ b/ps5-kstuff/uelf/fself.c
@@ -77,21 +77,45 @@ extern char decryptMultipleSelfBlocks_watchpoint_lr[];
 extern char decryptMultipleSelfBlocks_epilogue[];
 extern char mini_syscore_header[];
 
-static void set_dbgregs_for_watchpoint(uint64_t* regs, const uint64_t* dbgregs, size_t frame_size)
+static int set_dbgregs_for_watchpoint(uint64_t* regs, const uint64_t* dbgregs, size_t frame_size)
 {
-    uint64_t buf[frame_size/8 + 6];
-    pop_stack(regs, buf, frame_size);
-    read_dbgregs(buf + frame_size/8);
-    push_stack(regs, buf, sizeof(buf));
-    set_pcb_dbregs();
-    write_dbgregs(dbgregs);
+    uint64_t buf[frame_size/8 + 7];
+    uint64_t new_rsp;
+    uint64_t p_pcb_flags;
+    uint64_t pcb_flags_value;
+    int had_dbregs;
+    if(peek_stack_checked(regs, buf, frame_size))
+        return 0;
+    if(read_dbgregs_checked(buf + frame_size/8))
+        return 0;
+    if(get_current_pcb_flags_ptr_checked(&p_pcb_flags))
+        return 0;
+    if(get_pcb_dbregs_checked_at(p_pcb_flags, &pcb_flags_value, &had_dbregs))
+        return 0;
+    buf[frame_size/8 + 6] = had_dbregs;
+    new_rsp = regs[RSP] - (sizeof(buf) - frame_size);
+    if(copy_to_kernel(new_rsp, buf, sizeof(buf)))
+        return 0;
+    if(set_pcb_dbregs_checked_at(p_pcb_flags, pcb_flags_value))
+        return 0;
+    if(write_dbgregs_checked(dbgregs))
+    {
+        restore_dbgregs_state_checked_at(p_pcb_flags, pcb_flags_value, buf + frame_size/8, had_dbregs);
+        return 0;
+    }
+    regs[RSP] = new_rsp;
+    return 1;
 }
 
-static void unset_dbgregs_for_watchpoint(uint64_t* regs)
+static int unset_dbgregs_for_watchpoint(uint64_t* regs)
 {
-    uint64_t dbgregs[6];
-    pop_stack(regs, dbgregs, sizeof(dbgregs));
-    write_dbgregs(dbgregs);
+    uint64_t dbgregs[7];
+    if(peek_stack_checked(regs, dbgregs, sizeof(dbgregs)))
+        return 0;
+    if(restore_dbgregs_state_checked(dbgregs, dbgregs[6]))
+        return 0;
+    regs[RSP] += sizeof(dbgregs);
+    return 1;
 }
 
 static uint64_t dbgregs_for_fself[6] = {
@@ -124,14 +148,16 @@ void handle_fself_trap(uint64_t* regs, uint32_t trapno)
 {
     if (trapno == 1)
     {
-		uint64_t self_header = kpeek64(regs[(FWVER >= 0x800) ? RBX : R14] + 56);
-
         char fself_header_backup[(48 + mini_syscore_header_size + 15) & -16];
-        pop_stack(regs, fself_header_backup, sizeof(fself_header_backup));
-
+        uint64_t self_header;
+        if(peek_stack_checked(regs, fself_header_backup, sizeof(fself_header_backup)))
+            return;
+        if(kpeek64_checked(regs[(FWVER >= 0x800) ? RBX : R14] + 56, &self_header))
+            return;
+        if(copy_to_kernel(self_header, fself_header_backup + 40, mini_syscore_header_size))
+            return;
+        regs[RSP] += sizeof(fself_header_backup);
         regs[RIP] = *(uint64_t*)(fself_header_backup + sizeof(fself_header_backup) - 8);
-
-        copy_to_kernel(self_header, fself_header_backup + 40, mini_syscore_header_size);
     }
 }
 
@@ -142,83 +168,106 @@ int try_handle_fself_mailbox(uint64_t* regs, uint64_t lr)
     {
 		uint64_t self_header = kpeek64(regs[(FWVER >= 0x800) ? RBX : R14] + 56);
 		uint32_t size;
-        copy_from_kernel(&size, regs[RDX]+16, 4);
+        if(copy_from_kernel(&size, regs[RDX]+16, 4))
+            return 0;
         if(is_header_fself(self_header, size, 0, 0, 0, 0))
         {
             char fself_header_backup[(48 + mini_syscore_header_size + 15) & -16];
+            char mini_header[(mini_syscore_header_size + 15) & -16];
+            uint32_t original_size = size;
             uint64_t trap_frame[6] = {
                 (uint64_t)doreti_iret,
                 MKTRAP(TRAP_FSELF, 1), 0, 0, 0, 0,
             };
             memcpy(fself_header_backup, trap_frame, 48);
-            copy_from_kernel(fself_header_backup+48, self_header, mini_syscore_header_size);
-            push_stack(regs, fself_header_backup, sizeof(fself_header_backup));
-            copy_from_kernel(fself_header_backup+48, (uint64_t)mini_syscore_header, mini_syscore_header_size);
-            copy_to_kernel(self_header, fself_header_backup+48, mini_syscore_header_size);
+            if(copy_from_kernel(fself_header_backup+48, self_header, mini_syscore_header_size))
+                return 0;
+            if(copy_from_kernel(mini_header, (uint64_t)mini_syscore_header, mini_syscore_header_size))
+                return 0;
+            if(copy_to_kernel(self_header, mini_header, mini_syscore_header_size))
+                return 0;
             size = mini_syscore_header_size;
-            copy_to_kernel(regs[RDX]+16, &size, 4);
+            if(copy_to_kernel(regs[RDX]+16, &size, 4))
+            {
+                copy_to_kernel(self_header, fself_header_backup+48, mini_syscore_header_size);
+                return 0;
+            }
+            if(push_stack_checked(regs, fself_header_backup, sizeof(fself_header_backup)))
+            {
+                copy_to_kernel(self_header, fself_header_backup+48, mini_syscore_header_size);
+                copy_to_kernel(regs[RDX]+16, &original_size, 4);
+                return 0;
+            }
         }
     }
     else if(lr == (uint64_t)sceSblServiceMailbox_lr_loadSelfSegment)
     {
         uint64_t ctx[8];
-		copy_from_kernel(
+		if(copy_from_kernel(
     		ctx,
     		(FWVER >= 0x1000) ? kpeek64(regs[RBP] - 232) :
     		(FWVER >= 0x900 && FWVER <= 0x960) ? regs[R14] :
     		(FWVER >= 0x800 && FWVER <= 0x860) ? kpeek64(regs[RBP] - 240) :
     		regs[RBX],
     		sizeof(ctx)
-		);
+		))
+            return 0;
 
         if(is_header_fself(ctx[7], (uint32_t)ctx[1], 0, 0, 0, 0))
         {
-            pop_stack(regs, &regs[RIP], 8);
+            if(pop_stack_checked(regs, &regs[RIP], 8))
+                return 0;
             regs[RAX] = 0;
         }
     }
     else if(lr == (uint64_t)sceSblServiceMailbox_lr_decryptSelfBlock)
     {
         uint64_t ctx[8];
-		copy_from_kernel(
+		if(copy_from_kernel(
     		ctx,
     		(FWVER >= 0x800) ? regs[R12] :
     		(FWVER >= 0x500 && FWVER <= 0x761) ? kpeek64(regs[RBP] - 192) :
     		kpeek64(regs[RBP] - sceSblServiceMailbox_decryptSelfBlock_rsp_to_rbp +
-                     		sceSblServiceMailbox_decryptSelfBlock_rsp_to_self_context),
+    	                     		sceSblServiceMailbox_decryptSelfBlock_rsp_to_self_context),
     		sizeof(ctx)
-		);
+		))
+            return 0;
 
         if(is_header_fself(ctx[7], (uint32_t)ctx[1], 0, 0, 0, 0))
         {
             uint64_t request[8];
-            copy_from_kernel(request, regs[RDX], sizeof(request));
+            if(copy_from_kernel(request, regs[RDX], sizeof(request)))
+                return 0;
+            if(pop_stack_checked(regs, &regs[RIP], 8))
+                return 0;
             memcpy(DMEM+request[1], DMEM+request[2], (uint32_t)request[6]);
-            pop_stack(regs, &regs[RIP], 8);
             regs[RAX] = 0;
         }
     }
     else if(lr == (uint64_t)sceSblServiceMailbox_lr_decryptMultipleSelfBlocks)
     {
         uint64_t ctx[8];
-		copy_from_kernel(
+		if(copy_from_kernel(
     		ctx,
     		(FWVER >= 0x600) ? kpeek64(regs[RBP] - 208) :
     		(FWVER >= 0x500 && FWVER <= 0x550) ? kpeek64(regs[RBP] - 216) :
     		regs[R13],
     		sizeof(ctx)
-		);
+		))
+            return 0;
         
         if(is_header_fself(ctx[7], (uint32_t)ctx[1], 0, 0, 0, 0))
         {
             uint64_t request[8];
-            copy_from_kernel(request, regs[RDX], sizeof(request));
+            if(copy_from_kernel(request, regs[RDX], sizeof(request)))
+                return 0;
+            if(pop_stack_checked(regs, &regs[RIP], 8))
+                return 0;
             uint64_t* src = (uint64_t*)(DMEM + request[1]);
             uint64_t* dst = (uint64_t*)(DMEM + request[2]);
             uint32_t count = request[5];
             for(uint32_t i = 0; i < count; i++)
                 memcpy(DMEM+dst[i], DMEM+src[i], 16384);
-            pop_stack(regs, &regs[RIP], 8);
             regs[RAX] = 0;
         }
     }
@@ -241,6 +290,7 @@ int try_handle_fself_trap(uint64_t* regs)
         int is_ps4;
         if(is_header_fself(ctx[7], (uint32_t)ctx[1], &e_type, &is_ps4, authinfo, &have_authinfo))
         {
+            uint64_t ret_addr;
             uint64_t* p_authinfo;
             if(have_authinfo)
                 p_authinfo = authinfo;
@@ -258,29 +308,46 @@ int try_handle_fself_trap(uint64_t* regs)
                 else
                     p_authinfo = s_auth_info_for_exec;
             }
-            copy_to_kernel(regs[R8], p_authinfo, 0x88);
-            pop_stack(regs, &regs[RIP], 8);
+            if(copy_from_kernel(&ret_addr, regs[RSP], sizeof(ret_addr)))
+                return 1;
+            if(copy_to_kernel(regs[R8], p_authinfo, 0x88))
+                return 1;
+            if(copy_to_kernel(regs[RDI] + 62, &(const uint16_t[1]){0xdeb7}, 2))
+                return 1;
+            regs[RSP] += 8;
+            regs[RIP] = ret_addr;
             regs[RAX] = 0;
-            copy_to_kernel(regs[RDI] + 62, &(const uint16_t[1]){0xdeb7}, 2);
         }
     }
     else if(regs[RIP] == (uint64_t)loadSelfSegment_watchpoint)
     {
-		regs[(FWVER >= 0x800) ? RAX : R10] |= 0xffffull << 48;
-
         uint64_t frame[4];
-        copy_from_kernel(frame, regs[RSP], sizeof(frame));
+        if(copy_from_kernel(frame, regs[RSP], sizeof(frame)))
+            return 1;
+        regs[(FWVER >= 0x800) ? RAX : R10] |= 0xffffull << 48;
         if(frame[3] == (uint64_t)loadSelfSegment_watchpoint_lr)
-            set_dbgregs_for_watchpoint(regs, dbgregs_for_loadSelfSegment, sizeof(frame));
+        {
+            if(!set_dbgregs_for_watchpoint(regs, dbgregs_for_loadSelfSegment, sizeof(frame)))
+                return 1;
+        }
         else if(frame[3] == (uint64_t)decryptSelfBlock_watchpoint_lr)
-            set_dbgregs_for_watchpoint(regs, dbgregs_for_decryptSelfBlock, sizeof(frame));
+        {
+            if(!set_dbgregs_for_watchpoint(regs, dbgregs_for_decryptSelfBlock, sizeof(frame)))
+                return 1;
+        }
         else if(frame[3] == (uint64_t)decryptMultipleSelfBlocks_watchpoint_lr)
-            set_dbgregs_for_watchpoint(regs, dbgregs_for_decryptMultipleSelfBlocks, sizeof(frame));
+        {
+            if(!set_dbgregs_for_watchpoint(regs, dbgregs_for_decryptMultipleSelfBlocks, sizeof(frame)))
+                return 1;
+        }
     }
     else if(regs[RIP] == (uint64_t)loadSelfSegment_epilogue
          || regs[RIP] == (uint64_t)decryptSelfBlock_epilogue
          || regs[RIP] == (uint64_t)decryptMultipleSelfBlocks_epilogue)
-         unset_dbgregs_for_watchpoint(regs);
+    {
+         if(!unset_dbgregs_for_watchpoint(regs))
+             return 1;
+    }
     else
         return 0;
     return 1;

--- a/ps5-kstuff/uelf/fself.c
+++ b/ps5-kstuff/uelf/fself.c
@@ -124,7 +124,7 @@ void handle_fself_trap(uint64_t* regs, uint32_t trapno)
 {
     if (trapno == 1)
     {
-		uint64_t self_header = kpeek64(regs[(fwver >= 0x800) ? RBX : R14] + 56);
+		uint64_t self_header = kpeek64(regs[(FWVER >= 0x800) ? RBX : R14] + 56);
 
         char fself_header_backup[(48 + mini_syscore_header_size + 15) & -16];
         pop_stack(regs, fself_header_backup, sizeof(fself_header_backup));
@@ -140,7 +140,7 @@ int try_handle_fself_mailbox(uint64_t* regs, uint64_t lr)
 {
     if(lr == (uint64_t)sceSblServiceMailbox_lr_verifyHeader)
     {
-		uint64_t self_header = kpeek64(regs[(fwver >= 0x800) ? RBX : R14] + 56);
+		uint64_t self_header = kpeek64(regs[(FWVER >= 0x800) ? RBX : R14] + 56);
 		uint32_t size;
         copy_from_kernel(&size, regs[RDX]+16, 4);
         if(is_header_fself(self_header, size, 0, 0, 0, 0))
@@ -164,9 +164,9 @@ int try_handle_fself_mailbox(uint64_t* regs, uint64_t lr)
         uint64_t ctx[8];
 		copy_from_kernel(
     		ctx,
-    		(fwver >= 0x1000) ? kpeek64(regs[RBP] - 232) :
-    		(fwver >= 0x900 && fwver <= 0x960) ? regs[R14] :
-    		(fwver >= 0x800 && fwver <= 0x860) ? kpeek64(regs[RBP] - 240) :
+    		(FWVER >= 0x1000) ? kpeek64(regs[RBP] - 232) :
+    		(FWVER >= 0x900 && FWVER <= 0x960) ? regs[R14] :
+    		(FWVER >= 0x800 && FWVER <= 0x860) ? kpeek64(regs[RBP] - 240) :
     		regs[RBX],
     		sizeof(ctx)
 		);
@@ -182,8 +182,8 @@ int try_handle_fself_mailbox(uint64_t* regs, uint64_t lr)
         uint64_t ctx[8];
 		copy_from_kernel(
     		ctx,
-    		(fwver >= 0x800) ? regs[R12] :
-    		(fwver >= 0x500 && fwver <= 0x761) ? kpeek64(regs[RBP] - 192) :
+    		(FWVER >= 0x800) ? regs[R12] :
+    		(FWVER >= 0x500 && FWVER <= 0x761) ? kpeek64(regs[RBP] - 192) :
     		kpeek64(regs[RBP] - sceSblServiceMailbox_decryptSelfBlock_rsp_to_rbp +
                      		sceSblServiceMailbox_decryptSelfBlock_rsp_to_self_context),
     		sizeof(ctx)
@@ -203,8 +203,8 @@ int try_handle_fself_mailbox(uint64_t* regs, uint64_t lr)
         uint64_t ctx[8];
 		copy_from_kernel(
     		ctx,
-    		(fwver >= 0x600) ? kpeek64(regs[RBP] - 208) :
-    		(fwver >= 0x500 && fwver <= 0x550) ? kpeek64(regs[RBP] - 216) :
+    		(FWVER >= 0x600) ? kpeek64(regs[RBP] - 208) :
+    		(FWVER >= 0x500 && FWVER <= 0x550) ? kpeek64(regs[RBP] - 216) :
     		regs[R13],
     		sizeof(ctx)
 		);
@@ -266,7 +266,7 @@ int try_handle_fself_trap(uint64_t* regs)
     }
     else if(regs[RIP] == (uint64_t)loadSelfSegment_watchpoint)
     {
-		regs[(fwver >= 0x800) ? RAX : R10] |= 0xffffull << 48;
+		regs[(FWVER >= 0x800) ? RAX : R10] |= 0xffffull << 48;
 
         uint64_t frame[4];
         copy_from_kernel(frame, regs[RSP], sizeof(frame));

--- a/ps5-kstuff/uelf/kekcall.c
+++ b/ps5-kstuff/uelf/kekcall.c
@@ -22,14 +22,23 @@ int handle_kekcall(uint64_t* regs, uint64_t* args, uint32_t nr)
             (uint64_t)doreti_iret,
             (uint64_t)nop_ret, regs[CS], regs[EFLAGS], regs[RSP], regs[SS],
         };
-        read_dbgregs(stack_frame+6);
-        if(!get_pcb_dbregs())
+        int have_dbgregs;
+        if(read_dbgregs_checked(stack_frame+6))
+            return EFAULT;
+        if(get_pcb_dbregs_checked(&have_dbgregs))
+            return EFAULT;
+        if(!have_dbgregs)
         {
             stack_frame[6] = stack_frame[7] = stack_frame[8] = stack_frame[9] = 0;
             stack_frame[10] &= -16;
         }
-        push_stack(regs, stack_frame, sizeof(stack_frame));
-        kpoke64(regs[RDI]+td_retval, 0);
+        if(push_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+            return EFAULT;
+        if(copy_to_kernel(regs[RDI]+td_retval, &(const uint64_t){0}, sizeof(uint64_t)))
+        {
+            regs[RSP] += sizeof(stack_frame);
+            return EFAULT;
+        }
         regs[RDI] = regs[RSP] + 48;
         regs[RSI] = args[RDI];
         regs[RDX] = 48;
@@ -38,7 +47,8 @@ int handle_kekcall(uint64_t* regs, uint64_t* args, uint32_t nr)
     else if(nr == 2)
     {
         uint64_t stack_frame[14] = {(uint64_t)doreti_iret, MKTRAP(TRAP_KEKCALL, 1), [12] = regs[RDI]};
-        push_stack(regs, stack_frame, sizeof(stack_frame));
+        if(push_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+            return EFAULT;
         regs[RDI] = args[RDI];
         regs[RSI] = regs[RSP] + 48;
         regs[RDX] = 48;
@@ -55,7 +65,8 @@ int handle_kekcall(uint64_t* regs, uint64_t* args, uint32_t nr)
         stack_frame[6] = args[RDI];
         stack_frame[7] = args[RSI];
         stack_frame[14] = regs[RDI];
-        push_stack(regs, stack_frame, sizeof(stack_frame));
+        if(push_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+            return EFAULT;
         regs[RDI] = args[RDX];
         regs[RSI] = regs[RSP] + 64;
         regs[RDX] = 48;
@@ -74,49 +85,105 @@ void handle_kekcall_trap(uint64_t* regs, uint32_t trap)
     if(trap == 1)
     {
         uint64_t stack_frame[14];
-        pop_stack(regs, stack_frame, sizeof(stack_frame));
+        uint64_t old_dbgregs[6];
+        uint64_t p_pcb_flags;
+        uint64_t pcb_flags_value;
+        int had_dbgregs;
+        if(pop_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+            return;
         regs[RIP] = stack_frame[13];
         if((uint32_t)regs[RAX])
             return;
-        kpoke64(stack_frame[11]+td_retval, 0);
-        set_pcb_dbregs();
-        write_dbgregs(stack_frame+5);
+        if(copy_to_kernel(stack_frame[11]+td_retval, &(const uint64_t){0}, sizeof(uint64_t)))
+        {
+            regs[RAX] = EFAULT;
+            return;
+        }
+        if(read_dbgregs_checked(old_dbgregs)
+        || get_current_pcb_flags_ptr_checked(&p_pcb_flags)
+        || get_pcb_dbregs_checked_at(p_pcb_flags, &pcb_flags_value, &had_dbgregs))
+        {
+            regs[RAX] = EFAULT;
+            return;
+        }
+        if(set_pcb_dbregs_checked_at(p_pcb_flags, pcb_flags_value))
+        {
+            regs[RAX] = EFAULT;
+            return;
+        }
+        if(write_dbgregs_checked(stack_frame+5))
+        {
+            restore_dbgregs_state_checked_at(p_pcb_flags, pcb_flags_value, old_dbgregs, had_dbgregs);
+            regs[RAX] = EFAULT;
+        }
     }
     else if(trap == 2)
     {
         uint64_t stack_frame[15];
-        pop_stack(regs, stack_frame, sizeof(stack_frame));
+        if(pop_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+            return;
         if((uint32_t)regs[RAX])
         {
-            pop_stack(regs, &regs[RIP], 8);
+            if(pop_stack_checked(regs, &regs[RIP], 8))
+                return;
             return;
         }
         uint32_t pid = stack_frame[5];
         uint32_t sysc_no = stack_frame[6];
-        int64_t proc = kpeek64(stack_frame[13]+td_proc);
+        uint64_t proc_u;
+        if(kpeek64_checked(stack_frame[13]+td_proc, &proc_u))
+            goto fail_remote_syscall;
+        int64_t proc = proc_u;
         while(proc < -0x100000000)
-            proc = kpeek64(proc+8);
-        while(proc && (uint32_t)kpeek64(proc+p_pid) != pid)
-            proc = kpeek64(proc);
+        {
+            if(kpeek64_checked(proc+8, &proc_u))
+                goto fail_remote_syscall;
+            proc = proc_u;
+        }
+        while(proc)
+        {
+            uint64_t proc_pid;
+            if(kpeek64_checked(proc+p_pid, &proc_pid))
+                goto fail_remote_syscall;
+            if((uint32_t)proc_pid == pid)
+                break;
+            if(kpeek64_checked(proc, &proc_u))
+                goto fail_remote_syscall;
+            proc = proc_u;
+        }
         if(!proc)
         {
             regs[RAX] = ESRCH;
-            pop_stack(regs, &regs[RIP], 8);
+            if(pop_stack_checked(regs, &regs[RIP], 8))
+                return;
             return;
         }
-        regs[RDI] = kpeek64(proc+16);
+        if(kpeek64_checked(proc+16, &regs[RDI]))
+            goto fail_remote_syscall;
         uint64_t stack_frame_2[14] = {(uint64_t)doreti_iret, MKTRAP(TRAP_KEKCALL, 3), [6] = stack_frame[13], regs[RDI]};
         memcpy(stack_frame_2+8, stack_frame+7, 48);
+        uint64_t sysc_target = 0;
         if(sysc_no == SYS_sysarch && (uint32_t)stack_frame[7] == AMD64_GET_FSBASE)
         {
             stack_frame_2[1] = MKTRAP(TRAP_KEKCALL, 4);
-            
-            stack_frame_2[8] = kpeek64(get_pcb_field_ptr(get_thread_pcb(regs[RDI]), pcb_fsbase));
-            kpoke64(stack_frame[13]+td_retval, 0);
+
+            uint64_t thread_pcb;
+            if(kpeek64_checked(regs[RDI] + td_pcb, &thread_pcb))
+                goto fail_remote_syscall;
+            if(kpeek64_checked(get_pcb_field_ptr(thread_pcb, pcb_fsbase), &stack_frame_2[8]))
+                goto fail_remote_syscall;
+            if(copy_to_kernel(stack_frame[13]+td_retval, &(const uint64_t){0}, sizeof(uint64_t)))
+                goto fail_remote_syscall;
         }
         else
-            kpoke64(regs[RDI]+td_retval, 0);
-        push_stack(regs, stack_frame_2, sizeof(stack_frame_2));
+        {
+            if(kpeek64_checked((uint64_t)&sysents[sysc_no].sy_call, &sysc_target))
+                goto fail_remote_syscall;
+            if(copy_to_kernel(regs[RDI]+td_retval, &(const uint64_t){0}, sizeof(uint64_t)))
+                goto fail_remote_syscall;
+        }
+        if(push_stack_checked(regs, stack_frame_2, sizeof(stack_frame_2)))
+            goto fail_remote_syscall;
         regs[RAX] = (uint64_t)&sysents[sysc_no];
         if(sysc_no == SYS_sysarch && (uint32_t)stack_frame[7] == AMD64_GET_FSBASE)
         {
@@ -127,17 +194,30 @@ void handle_kekcall_trap(uint64_t* regs, uint32_t trap)
         }
         else
         {
-            regs[RIP] = kpeek64((uint64_t)&sysents[sysc_no].sy_call);
+            regs[RIP] = sysc_target;
             regs[RSI] = regs[RSP] + 64;
             handle_syscall(regs, 0);
         }
+        return;
+fail_remote_syscall:
+        regs[RAX] = EFAULT;
+        if(pop_stack_checked(regs, &regs[RIP], 8))
+            return;
+        return;
     }
     else if(trap == 3 || trap == 4)
     {
         uint64_t stack_frame[14];
-        pop_stack(regs, stack_frame, sizeof(stack_frame));
+        if(pop_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+            return;
         if(trap == 3 && !(uint32_t)regs[RAX])
-            kpoke64(stack_frame[5]+td_retval, kpeek64(stack_frame[6]+td_retval));
+        {
+            uint64_t retval;
+            if(kpeek64_checked(stack_frame[6]+td_retval, &retval))
+                regs[RAX] = EFAULT;
+            else
+                kpoke64(stack_frame[5]+td_retval, retval);
+        }
         regs[RIP] = stack_frame[13];
     }
 }

--- a/ps5-kstuff/uelf/kekcall.c
+++ b/ps5-kstuff/uelf/kekcall.c
@@ -111,7 +111,7 @@ void handle_kekcall_trap(uint64_t* regs, uint32_t trap)
         {
             stack_frame_2[1] = MKTRAP(TRAP_KEKCALL, 4);
             
-            stack_frame_2[8] = kpeek64(kpeek64(regs[RDI]+td_pcb) + pcb_fsbase + (fwver >= 0x1000 ? 0x10 : 0));
+            stack_frame_2[8] = kpeek64(get_pcb_field_ptr(get_thread_pcb(regs[RDI]), pcb_fsbase));
             kpoke64(stack_frame[13]+td_retval, 0);
         }
         else

--- a/ps5-kstuff/uelf/main.c
+++ b/ps5-kstuff/uelf/main.c
@@ -87,7 +87,7 @@ from_userspace:
         if((regs[CS] & 3)) //from userspace
         {
             //determine correct gsbase for userspace
-            uint64_t gsbase = kpeek64(kpeek64(kpeek64((uint64_t)pcpu)+td_pcb)+pcb_gsbase+(fwver >= 0x1000 ? 0x10 : 0));
+            uint64_t gsbase = kpeek64(get_pcb_field_ptr(get_current_pcb(), pcb_gsbase));
             //arm wrmsr in the exit path
             uint64_t args[3] = {gsbase >> 32, 0xc0000101, (uint32_t)gsbase};
             copy_to_kernel(wrmsr_args, args, sizeof(args));

--- a/ps5-kstuff/uelf/main.c
+++ b/ps5-kstuff/uelf/main.c
@@ -30,6 +30,7 @@ extern uint64_t wrmsr_args;
 
 void handle_syscall(uint64_t* regs, int allow_kekcall)
 {
+    const uint64_t syscall_extra = (FWVER >= 0x1000 ? 0x10 : 0);
 #define IS_PPR(which) (regs[RAX] == (uint64_t)&sysents[SYS_##which])
 #ifdef FREEBSD
 #define IS_PS4(which) 0
@@ -39,15 +40,22 @@ void handle_syscall(uint64_t* regs, int allow_kekcall)
 #define IS(which) (IS_PPR(which) || IS_PS4(which))
     if(IS_PPR(getppid) && allow_kekcall)
     {
+        enum { KEKCALL_ARGS_OFFSET_MAX = syscall_rsp_to_regs_stash + 0x10 + 8 };
+        uint8_t syscall_frame[KEKCALL_ARGS_OFFSET_MAX + sizeof(uint64_t) * NREGS];
         uint64_t args[NREGS] = {0};
-        copy_from_kernel(args, regs[RSP]+syscall_rsp_to_regs_stash+(FWVER >= 0x1000 ? 0x10 : 0)+8, sizeof(args));
+        uint64_t args_offset = syscall_rsp_to_regs_stash + syscall_extra + 8;
+        if(copy_from_kernel(syscall_frame, regs[RSP], args_offset + sizeof(args)))
+            return;
+        memcpy(args, syscall_frame + args_offset, sizeof(args));
         int err = handle_kekcall(regs, args, args[RAX]>>32);
         if(err != ENOSYS)
         {
+            uint64_t syscall_lr = *(const uint64_t*)syscall_frame;
             if(!err)
                 kpoke64(regs[RDI]+td_retval, args[RAX]);
             regs[RAX] = err;
-            pop_stack(regs, &regs[RIP], 8);
+            regs[RSP] += 8;
+            regs[RIP] = syscall_lr;
         }
     }
 #ifndef FREEBSD
@@ -79,18 +87,29 @@ void handle_syscall(uint64_t* regs, int allow_kekcall)
 
 void handle(uint64_t* regs)
 {
-    if(!(regs[CS] & 3))
+    const int initial_from_user = !!(regs[CS] & 3);
+    const int initial_from_copyio = !!(regs[EFLAGS] & 0x40000);
+    const uint64_t syscall_extra = (FWVER >= 0x1000 ? 0x10 : 0);
+    if(!initial_from_user)
         regs[EFLAGS] |= 0x10000; //RF
-    if((regs[CS] & 3) || (regs[EFLAGS] & 0x40000)) //from userspace, or from copyin/copyout
+    if(initial_from_user || initial_from_copyio) //from userspace, or from copyin/copyout
     {
 from_userspace:
-        if((regs[CS] & 3)) //from userspace
+        {
+        const int from_user = !!(regs[CS] & 3);
+        if(from_user) //from userspace
         {
             //determine correct gsbase for userspace
-            uint64_t gsbase = kpeek64(get_pcb_field_ptr(get_current_pcb(), pcb_gsbase));
+            uint64_t pcb;
+            uint64_t gsbase;
+            if(get_current_pcb_checked(&pcb))
+                return;
+            if(copy_from_kernel(&gsbase, get_pcb_field_ptr(pcb, pcb_gsbase), sizeof(gsbase)))
+                return;
             //arm wrmsr in the exit path
             uint64_t args[3] = {gsbase >> 32, 0xc0000101, (uint32_t)gsbase};
-            copy_to_kernel(wrmsr_args, args, sizeof(args));
+            if(copy_to_kernel(wrmsr_args, args, sizeof(args)))
+                return;
         }
         //inject a fake #DB or #GP exception
         uint64_t stack;
@@ -100,8 +119,11 @@ from_userspace:
         else
 #endif
         {
-            if((regs[CS] & 3))
-                copy_from_kernel(&stack, (uint64_t)tss+4, 8);
+            if(from_user)
+            {
+                if(copy_from_kernel(&stack, (uint64_t)tss+4, 8))
+                    return;
+            }
             else
                 stack = regs[RSP];
         }
@@ -109,36 +131,46 @@ from_userspace:
         if(have_error_code)
         {
             stack -= 48;
-            copy_to_kernel(stack, &regs[ERRC], 48);
+            if(copy_to_kernel(stack, &regs[ERRC], 48))
+                return;
             regs[RIP] = (uint64_t)int13_handler;
         }
         else
         {
             stack -= 40;
-            copy_to_kernel(stack, &regs[RIP], 40);
+            if(copy_to_kernel(stack, &regs[RIP], 40))
+                return;
             regs[RIP] = (uint64_t)int1_handler;
         }
         regs[CS] = 0x20;
         regs[EFLAGS] = 2;
         regs[RSP] = stack;
         regs[SS] = 0;
+        }
     }
     else if(regs[RIP] == (uint64_t)syscall_before)
     {
+        uint64_t syscall_target;
         regs[RAX] |= 0xffffull << 48;
-        regs[RSI] = regs[RSP] + syscall_rsp_to_rsi+(FWVER >= 0x1000 ? 0x10 : 0);
-        push_stack(regs, (const uint64_t[1]){(uint64_t)syscall_after}, 8);
-        regs[RIP] = kpeek64(regs[RAX]+8);
+        regs[RSI] = regs[RSP] + syscall_rsp_to_rsi + syscall_extra;
+        if(copy_from_kernel(&syscall_target, regs[RAX]+8, sizeof(syscall_target)))
+            return;
+        if(push_stack_checked(regs, (const uint64_t[1]){(uint64_t)syscall_after}, 8))
+            return;
+        regs[RIP] = syscall_target;
         handle_syscall(regs, 1);
     }
     else if(regs[RIP] == (uint64_t)doreti_iret)
     {
         uint64_t frame[5];
-        copy_from_kernel(frame, regs[RSP], sizeof(frame));
+        if(copy_from_kernel(frame, regs[RSP], 16))
+            return;
         if((frame[1] & 3)) //#GP in iret to userspace
         {
             //pretend that the #GP was inside userspace
             //stock kernel crashes on this, lol
+            if(copy_from_kernel(frame + 2, regs[RSP] + 16, sizeof(frame) - 16))
+                return;
             memcpy(&regs[RIP], frame, sizeof(frame));
             goto from_userspace;
         }
@@ -196,9 +228,11 @@ from_userspace:
 void main(uint64_t just_return)
 {
     uint64_t regs[NREGS];
-    copy_from_kernel(regs, trap_frame, sizeof(regs));
+    if(copy_from_kernel(regs, trap_frame, sizeof(regs)))
+        return;
     uint64_t jr_frame[5];
-    copy_from_kernel(jr_frame, just_return, 40);
+    if(copy_from_kernel(jr_frame, just_return, 40))
+        return;
     have_error_code = jr_frame[0];
     regs[RDX] = jr_frame[2];
     regs[RCX] = jr_frame[3];

--- a/ps5-kstuff/uelf/main.c
+++ b/ps5-kstuff/uelf/main.c
@@ -40,7 +40,7 @@ void handle_syscall(uint64_t* regs, int allow_kekcall)
     if(IS_PPR(getppid) && allow_kekcall)
     {
         uint64_t args[NREGS] = {0};
-        copy_from_kernel(args, regs[RSP]+syscall_rsp_to_regs_stash+(fwver >= 0x1000 ? 0x10 : 0)+8, sizeof(args));
+        copy_from_kernel(args, regs[RSP]+syscall_rsp_to_regs_stash+(FWVER >= 0x1000 ? 0x10 : 0)+8, sizeof(args));
         int err = handle_kekcall(regs, args, args[RAX]>>32);
         if(err != ENOSYS)
         {
@@ -126,7 +126,7 @@ from_userspace:
     else if(regs[RIP] == (uint64_t)syscall_before)
     {
         regs[RAX] |= 0xffffull << 48;
-        regs[RSI] = regs[RSP] + syscall_rsp_to_rsi+(fwver >= 0x1000 ? 0x10 : 0);
+        regs[RSI] = regs[RSP] + syscall_rsp_to_rsi+(FWVER >= 0x1000 ? 0x10 : 0);
         push_stack(regs, (const uint64_t[1]){(uint64_t)syscall_after}, 8);
         regs[RIP] = kpeek64(regs[RAX]+8);
         handle_syscall(regs, 1);

--- a/ps5-kstuff/uelf/npdrm.c
+++ b/ps5-kstuff/uelf/npdrm.c
@@ -22,7 +22,8 @@ int aes_cbc_128_decrypt(uint8_t *out, const uint8_t *in, int size, const uint8_t
 {
     int err = -1;
     static int aes_cipher = -1;
-    uelf_fpu_enter();
+    if (uelf_fpu_enter())
+        return -1;
     if (aes_cipher < 0)
     {
         if ((aes_cipher = register_cipher(&aes_desc)) < 0) goto exit;
@@ -37,12 +38,13 @@ exit:
     return err;
 }
 
-int sha256_buffer(const unsigned char *in, unsigned long inlen, unsigned char *out)
+static int sha256_buffer_fpu_held(const unsigned char *in, unsigned long inlen, unsigned char *out)
 {
     hash_state md;
     int err = -1;
 
-    uelf_fpu_enter();
+    if (uelf_fpu_enter())
+        return -1;
     if ((err = sha256_init(&md)) != CRYPT_OK) goto exit;
     if ((err = sha256_process(&md, in, inlen)) != CRYPT_OK) goto exit;
     if ((err = sha256_done(&md, out)) != CRYPT_OK) goto exit;
@@ -67,28 +69,36 @@ int memcmp(const void *s1, const void *s2, size_t n)
 
 int try_handle_npdrm_mailbox(uint64_t *regs, uint64_t lr)
 {
+    struct {
+        uint32_t cmd;
+        uint32_t _pad;
+        uint64_t rif_pa;
+    } request_hdr;
 #ifndef NPDRM_PORTING
     if (lr != (uint64_t)sceSblServiceMailbox_lr_npdrm_cmd_5 &&
         lr != (uint64_t)sceSblServiceMailbox_lr_npdrm_cmd_6)
     {
         return 0;
     }
+    if (copy_from_kernel(&request_hdr, regs[RDX], sizeof(request_hdr)))
+    {
+        return 1;
+    }
 #else
-    uint32_t cmd;
-    if (copy_from_kernel(&cmd, regs[RDX], sizeof(cmd)))
+    if (copy_from_kernel(&request_hdr, regs[RDX], sizeof(request_hdr)))
     {
         return 0;
     }
     // Other functions may use this same cmd number for different purposes (depending on RDI/handle i believe, however its value changes between fws)
     // for example, sceSblServiceMailbox_lr_decryptSelfBlock also sees cmd 6
     // if we only relied on this, it would work safely because of the later checks, its just wasteful
-    if (cmd != 5 && cmd != 6)
+    if (request_hdr.cmd != 5 && request_hdr.cmd != 6)
     {
         return 0;
     }
 #endif
 
-    uint64_t rif_pa = kpeek64(regs[RDX] + 0x8);
+    uint64_t rif_pa = request_hdr.rif_pa;
 
     struct RifCmd56MemoryLayout layout;
     memcpy(&layout, DMEM + rif_pa, sizeof(layout));
@@ -103,7 +113,7 @@ int try_handle_npdrm_mailbox(uint64_t *regs, uint64_t lr)
     }
 
     uint8_t contentid_hash[32];
-    if (sha256_buffer(layout.rif.contentId, sizeof(layout.rif.contentId), contentid_hash))
+    if (sha256_buffer_fpu_held(layout.rif.contentId, sizeof(layout.rif.contentId), contentid_hash))
     {
 #ifdef NPDRM_PORTING
         return 0;
@@ -124,7 +134,7 @@ int try_handle_npdrm_mailbox(uint64_t *regs, uint64_t lr)
 
 #ifdef NPDRM_PORTING
     // Now that we know the input data is a (debug) rif, we know we are at the right place
-    log_word(0x10C7100000000001UL + (cmd << 16));
+    log_word(0x10C7100000000001UL + ((uint64_t)request_hdr.cmd << 16));
     log_word(lr);
 #endif
 
@@ -155,7 +165,7 @@ int try_handle_npdrm_mailbox(uint64_t *regs, uint64_t lr)
     }
 
 #ifdef NPDRM_PORTING
-    if (cmd == 6)
+    if (request_hdr.cmd == 6)
 #else
     if (lr == (uint64_t)sceSblServiceMailbox_lr_npdrm_cmd_6)
 #endif
@@ -173,13 +183,19 @@ int try_handle_npdrm_mailbox(uint64_t *regs, uint64_t lr)
         }
 
         // copy both unk10 and unk20
-        copy_to_kernel(regs[RDX] + __builtin_offsetof(struct NpDrmCmd6, unk10), &decrypted_secret[0x70], 0x20);
+        if(copy_to_kernel(regs[RDX] + __builtin_offsetof(struct NpDrmCmd6, unk10), &decrypted_secret[0x70], 0x20))
+        {
+            return 1;
+        }
     }
 
     memcpy(DMEM + rif_pa + __builtin_offsetof(struct RifCmd56MemoryLayout, output), &layout.output, sizeof(layout.output));
 
     uint32_t res = 0;
-    copy_to_kernel(regs[RDX] + 0x4, &res, sizeof(res));
+    if(copy_to_kernel(regs[RDX] + 0x4, &res, sizeof(res)))
+    {
+        return 1;
+    }
 
     regs[RIP] = lr;
     regs[RAX] = 0;

--- a/ps5-kstuff/uelf/pfs_crypto.c
+++ b/ps5-kstuff/uelf/pfs_crypto.c
@@ -31,7 +31,8 @@ static void pfs_gen_key(uint32_t idx, const uint8_t* seed, const uint8_t* ekpfs,
 
 int pfs_derive_fake_keys(const uint8_t* p_eekpfs, const uint8_t* crypt_seed, uint8_t* ek, uint8_t* sk)
 {
-    uelf_fpu_enter();
+    if(uelf_fpu_enter())
+        return 0;
     int ans = 0;
     uint8_t eekpfs[256];
     memcpy(eekpfs, p_eekpfs, 256);
@@ -55,7 +56,8 @@ exit:
 
 int pfs_hmac_virtual(uint8_t* out, const uint8_t* key, uint64_t data, size_t data_size)
 {
-    uelf_fpu_enter();
+    if(uelf_fpu_enter())
+        return -1;
     br_hmac_key_context key_ctx;
     br_hmac_key_init(&key_ctx, &br_sha256_vtable, key, 32);
     br_hmac_context ctx;
@@ -86,7 +88,8 @@ int pfs_xts_virtual(uint64_t dst, uint64_t src, const uint8_t* key, uint64_t sta
     enum { SECTOR_SIZE = 4096 };
     static int aes_cipher = -1;
     int ans = -1;
-    uelf_fpu_enter();
+    if(uelf_fpu_enter())
+        return -1;
     if(aes_cipher < 0)
     {
         aes_cipher = register_cipher(&aes_desc);

--- a/ps5-kstuff/uelf/utils.c
+++ b/ps5-kstuff/uelf/utils.c
@@ -80,16 +80,20 @@ int copy_to_kernel(uint64_t dst, const void* src, uint64_t sz)
 
 uint64_t yield(void);
 
-void run_gadget(uint64_t* regs)
+int run_gadget_checked(uint64_t* regs)
 {
-    copy_to_kernel(trap_frame, regs, NREGS*8);
+    if(copy_to_kernel(trap_frame, regs, NREGS*8))
+        return EFAULT;
     uint64_t just_return = yield();
     uint64_t jr_frame[5];
-    copy_from_kernel(regs, trap_frame, NREGS*8);
-    copy_from_kernel(jr_frame, just_return, 40);
+    if(copy_from_kernel(regs, trap_frame, NREGS*8))
+        return EFAULT;
+    if(copy_from_kernel(jr_frame, just_return, 40))
+        return EFAULT;
     regs[RDX] = jr_frame[2];
     regs[RCX] = jr_frame[3];
     regs[RAX] = jr_frame[4];
+    return 0;
 }
 
 extern char dr2gpr_start[];
@@ -103,19 +107,21 @@ extern char mov_cr0_rax[];
 extern char doreti_iret[];
 extern char syscall_after[];
 
-void read_dbgregs(uint64_t* dr)
+int read_dbgregs_checked(uint64_t* dr)
 {
     uint64_t regs[NREGS] = { [RIP] = (uint64_t)dr2gpr_start, 0x20, 2, 0, 0, [R8] = 0xdeadbeefdeadbeef };
-    run_gadget(regs);
+    if(run_gadget_checked(regs))
+        return EFAULT;
     dr[0] = regs[R15];
     dr[1] = regs[R14];
     dr[2] = regs[R13];
     dr[3] = regs[R12];
     dr[4] = regs[R11];
     dr[5] = regs[RAX];
+    return 0;
 }
 
-void write_dbgregs(const uint64_t* dr)
+int write_dbgregs_checked(const uint64_t* dr)
 {
     uint64_t regs[NREGS] = { [RIP] = (uint64_t)gpr2dr_1_start, 0x20, 2, 0, 0, [R8] = 0xdeadbeefdeadbeef };
     regs[R15] = dr[0];
@@ -125,12 +131,13 @@ void write_dbgregs(const uint64_t* dr)
     regs[R11] = dr[4];
     regs[RCX] = dr[5];
     regs[RAX] = dr[5];
-    run_gadget(regs);
+    if(run_gadget_checked(regs))
+        return EFAULT;
     regs[R11] = dr[4];
     regs[R15] = dr[5];
     regs[R12] = 0xdeadbeefdeadbeef;
     regs[RIP] = (uint64_t)gpr2dr_2_start;
-    run_gadget(regs);
+    return run_gadget_checked(regs);
 }
 
 int rdmsr(uint32_t which, uint64_t* ans)
@@ -139,7 +146,8 @@ int rdmsr(uint32_t which, uint64_t* ans)
         [RIP] = (uint64_t)rdmsr_start, 0x20, 0x102, 0, 0,
         [RCX] = which,
     };
-    run_gadget(regs);
+    if(run_gadget_checked(regs))
+        return 0;
     if(regs[RIP] == (uint64_t)rdmsr_start)
         return 0;
     *ans = regs[RDX] << 32 | (uint32_t)regs[RAX];
@@ -154,26 +162,29 @@ int wrmsr(uint32_t which, uint64_t value)
         [RAX] = (uint32_t)value,
         [RDX] = value >> 32,
     };
-    run_gadget(regs);
+    if(run_gadget_checked(regs))
+        return 0;
     return regs[RIP] != (uint64_t)wrmsr_ret;
 }
 
-uint64_t read_cr0(void)
+int read_cr0_checked(uint64_t* cr0)
 {
     uint64_t regs[NREGS] = {
         [RIP] = (uint64_t)mov_rax_cr0, 0x20, 0x102, 0, 0,
     };
-    run_gadget(regs);
-    return regs[RAX];
+    if(run_gadget_checked(regs))
+        return EFAULT;
+    *cr0 = regs[RAX];
+    return 0;
 }
 
-void write_cr0(uint64_t cr0)
+int write_cr0_checked(uint64_t cr0)
 {
     uint64_t regs[NREGS] = {
         [RIP] = (uint64_t)mov_cr0_rax, 0x20, 0x102, 0, 0,
         [RAX] = cr0,
     };
-    run_gadget(regs);
+    return run_gadget_checked(regs);
 }
 
 void start_syscall_with_dbgregs(uint64_t* regs, const uint64_t* dbgregs)
@@ -182,10 +193,27 @@ void start_syscall_with_dbgregs(uint64_t* regs, const uint64_t* dbgregs)
         (uint64_t)doreti_iret,
         MKTRAP(TRAP_UTILS, 1), 0, 0, 0, 0,
     };
-    read_dbgregs(stack_frame+6);
-    push_stack(regs, stack_frame, sizeof(stack_frame));
-    set_pcb_dbregs();
-    write_dbgregs(dbgregs);
+    uint64_t p_pcb_flags;
+    uint64_t pcb_flags_value;
+    int had_dbregs;
+    if(read_dbgregs_checked(stack_frame+6))
+        return;
+    if(get_current_pcb_flags_ptr_checked(&p_pcb_flags))
+        return;
+    if(get_pcb_dbregs_checked_at(p_pcb_flags, &pcb_flags_value, &had_dbregs))
+        return;
+    stack_frame[4] = had_dbregs;
+    if(push_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+        return;
+    if(set_pcb_dbregs_checked_at(p_pcb_flags, pcb_flags_value))
+        goto rollback_stack;
+    if(write_dbgregs_checked(dbgregs))
+    {
+        restore_dbgregs_state_checked_at(p_pcb_flags, pcb_flags_value, stack_frame+6, had_dbregs);
+rollback_stack:
+        regs[RSP] += sizeof(stack_frame);
+        return;
+    }
 }
 
 void handle_utils_trap(uint64_t* regs, uint32_t trapno)
@@ -193,8 +221,11 @@ void handle_utils_trap(uint64_t* regs, uint32_t trapno)
     if(trapno == 1)
     {
         uint64_t stack_frame[12];
-        pop_stack(regs, stack_frame, sizeof(stack_frame));
-        write_dbgregs(stack_frame+5);
+        if(peek_stack_checked(regs, stack_frame, sizeof(stack_frame)))
+            return;
+        if(restore_dbgregs_state_checked(stack_frame+5, stack_frame[4]))
+            return;
+        regs[RSP] += sizeof(stack_frame);
         regs[RIP] = stack_frame[11];
     }
 }

--- a/ps5-kstuff/uelf/utils.h
+++ b/ps5-kstuff/uelf/utils.h
@@ -11,6 +11,7 @@ extern char fwver[];
 
 extern char dmem[];
 #define DMEM dmem
+#define FWVER ((uint64_t)(uintptr_t)fwver)
 
 int virt2phys(uint64_t addr, uint64_t* phys, uint64_t* phys_limit);
 int copy_from_kernel(void* dst, uint64_t src, uint64_t sz);
@@ -53,7 +54,7 @@ static inline void pop_stack(uint64_t* regs, void* data, size_t sz)
 
 static inline uint64_t get_pcb_field_ptr(uint64_t pcb, uint64_t field_offset)
 {
-    return pcb + field_offset + (fwver >= 0x1000 ? 0x10 : 0);
+    return pcb + field_offset + (FWVER >= 0x1000 ? 0x10 : 0);
 }
 
 static inline uint64_t get_thread_pcb(uint64_t td)

--- a/ps5-kstuff/uelf/utils.h
+++ b/ps5-kstuff/uelf/utils.h
@@ -51,13 +51,28 @@ static inline void pop_stack(uint64_t* regs, void* data, size_t sz)
     regs[RSP] += sz;
 }
 
+static inline uint64_t get_pcb_field_ptr(uint64_t pcb, uint64_t field_offset)
+{
+    return pcb + field_offset + (fwver >= 0x1000 ? 0x10 : 0);
+}
+
+static inline uint64_t get_thread_pcb(uint64_t td)
+{
+    return kpeek64(td + td_pcb);
+}
+
+static inline uint64_t get_current_pcb(void)
+{
+    return get_thread_pcb(kpeek64((uint64_t)pcpu));
+}
+
 static inline int get_pcb_dbregs(void)
 {
-    return (kpeek64(kpeek64(kpeek64((uint64_t)pcpu)+td_pcb)+pcb_flags+(fwver >= 0x1000 ? 0x10 : 0)) & PCB_DBREGS) ? 1 : 0;
+    return (kpeek64(get_pcb_field_ptr(get_current_pcb(), pcb_flags)) & PCB_DBREGS) ? 1 : 0;
 }
 
 static inline void set_pcb_dbregs(void)
 {
-    uint64_t p_pcb_flags = kpeek64(kpeek64((uint64_t)pcpu)+td_pcb)+pcb_flags+(fwver >= 0x1000 ? 0x10 : 0);
+    uint64_t p_pcb_flags = get_pcb_field_ptr(get_current_pcb(), pcb_flags);
     kpoke64(p_pcb_flags, kpeek64(p_pcb_flags) | PCB_DBREGS);
 }

--- a/ps5-kstuff/uelf/utils.h
+++ b/ps5-kstuff/uelf/utils.h
@@ -16,21 +16,26 @@ extern char dmem[];
 int virt2phys(uint64_t addr, uint64_t* phys, uint64_t* phys_limit);
 int copy_from_kernel(void* dst, uint64_t src, uint64_t sz);
 int copy_to_kernel(uint64_t dst, const void* src, uint64_t sz);
-void run_gadget(uint64_t* regs);
-void read_dbgregs(uint64_t* dr);
-void write_dbgregs(const uint64_t* dr);
-uint64_t read_cr0(void);
-void write_cr0(uint64_t);
+int run_gadget_checked(uint64_t* regs);
+int read_dbgregs_checked(uint64_t* dr);
+int write_dbgregs_checked(const uint64_t* dr);
+int read_cr0_checked(uint64_t* cr0);
+int write_cr0_checked(uint64_t cr0);
 void start_syscall_with_dbgregs(uint64_t* regs, const uint64_t* dbgregs);
 void handle_utils_trap(uint64_t* regs, uint32_t trapno);
 void handle_syscall(uint64_t* regs, int allow_kekcall);
 int rdmsr(uint32_t which, uint64_t* ans);
 int wrmsr(uint32_t which, uint64_t value);
 
+static inline int kpeek64_checked(uintptr_t kptr, uint64_t* value)
+{
+    return copy_from_kernel(value, kptr, sizeof(*value));
+}
+
 static inline uint64_t kpeek64(uintptr_t kptr)
 {
     uint64_t ans = 0;
-    if(copy_from_kernel(&ans, kptr, sizeof(ans)))
+    if(kpeek64_checked(kptr, &ans))
         log_word((uint64_t)__builtin_return_address(0));
     return ans;
 }
@@ -40,16 +45,26 @@ static inline void kpoke64(uintptr_t kptr, uint64_t value)
     copy_to_kernel(kptr, &value, sizeof(value));
 }
 
-static inline void push_stack(uint64_t* regs, const void* data, size_t sz)
+static inline int push_stack_checked(uint64_t* regs, const void* data, size_t sz)
 {
-    regs[RSP] -= sz;
-    copy_to_kernel(regs[RSP], data, sz);
+    uint64_t rsp = regs[RSP] - sz;
+    if(copy_to_kernel(rsp, data, sz))
+        return 1;
+    regs[RSP] = rsp;
+    return 0;
 }
 
-static inline void pop_stack(uint64_t* regs, void* data, size_t sz)
+static inline int pop_stack_checked(uint64_t* regs, void* data, size_t sz)
 {
-    copy_from_kernel(data, regs[RSP], sz);
+    if(copy_from_kernel(data, regs[RSP], sz))
+        return 1;
     regs[RSP] += sz;
+    return 0;
+}
+
+static inline int peek_stack_checked(const uint64_t* regs, void* data, size_t sz)
+{
+    return copy_from_kernel(data, regs[RSP], sz);
 }
 
 static inline uint64_t get_pcb_field_ptr(uint64_t pcb, uint64_t field_offset)
@@ -57,23 +72,97 @@ static inline uint64_t get_pcb_field_ptr(uint64_t pcb, uint64_t field_offset)
     return pcb + field_offset + (FWVER >= 0x1000 ? 0x10 : 0);
 }
 
-static inline uint64_t get_thread_pcb(uint64_t td)
+static inline int get_thread_pcb_checked(uint64_t td, uint64_t* pcb)
 {
-    return kpeek64(td + td_pcb);
+    return kpeek64_checked(td + td_pcb, pcb);
 }
 
-static inline uint64_t get_current_pcb(void)
+static inline int get_current_pcb_checked(uint64_t* pcb)
 {
-    return get_thread_pcb(kpeek64((uint64_t)pcpu));
+    uint64_t td;
+    if(kpeek64_checked((uint64_t)pcpu, &td))
+        return 1;
+    return get_thread_pcb_checked(td, pcb);
 }
 
-static inline int get_pcb_dbregs(void)
+static inline int get_current_pcb_flags_ptr_checked(uint64_t* p_pcb_flags)
 {
-    return (kpeek64(get_pcb_field_ptr(get_current_pcb(), pcb_flags)) & PCB_DBREGS) ? 1 : 0;
+    uint64_t pcb;
+    if(get_current_pcb_checked(&pcb))
+        return 1;
+    *p_pcb_flags = get_pcb_field_ptr(pcb, pcb_flags);
+    return 0;
 }
 
-static inline void set_pcb_dbregs(void)
+static inline int get_pcb_dbregs_checked(int* enabled)
 {
-    uint64_t p_pcb_flags = get_pcb_field_ptr(get_current_pcb(), pcb_flags);
-    kpoke64(p_pcb_flags, kpeek64(p_pcb_flags) | PCB_DBREGS);
+    uint64_t flags;
+    uint64_t p_pcb_flags;
+    if(get_current_pcb_flags_ptr_checked(&p_pcb_flags))
+        return 1;
+    if(kpeek64_checked(p_pcb_flags, &flags))
+        return 1;
+    *enabled = !!(flags & PCB_DBREGS);
+    return 0;
+}
+
+static inline int get_pcb_dbregs_checked_at(uint64_t p_pcb_flags, uint64_t* flags, int* enabled)
+{
+    if(kpeek64_checked(p_pcb_flags, flags))
+        return 1;
+    *enabled = !!(*flags & PCB_DBREGS);
+    return 0;
+}
+
+static inline int set_pcb_dbregs_checked(void);
+static inline int clear_pcb_dbregs_checked(void);
+
+static inline int set_pcb_dbregs_checked(void)
+{
+    uint64_t p_pcb_flags;
+    uint64_t flags;
+    if(get_current_pcb_flags_ptr_checked(&p_pcb_flags))
+        return 1;
+    if(kpeek64_checked(p_pcb_flags, &flags))
+        return 1;
+    return copy_to_kernel(p_pcb_flags, &(const uint64_t){flags | PCB_DBREGS}, sizeof(uint64_t));
+}
+
+static inline int set_pcb_dbregs_checked_at(uint64_t p_pcb_flags, uint64_t flags)
+{
+    return copy_to_kernel(p_pcb_flags, &(const uint64_t){flags | PCB_DBREGS}, sizeof(uint64_t));
+}
+
+static inline int clear_pcb_dbregs_checked(void)
+{
+    uint64_t p_pcb_flags;
+    uint64_t flags;
+    if(get_current_pcb_flags_ptr_checked(&p_pcb_flags))
+        return 1;
+    if(kpeek64_checked(p_pcb_flags, &flags))
+        return 1;
+    return copy_to_kernel(p_pcb_flags, &(const uint64_t){flags & ~PCB_DBREGS}, sizeof(uint64_t));
+}
+
+static inline int clear_pcb_dbregs_checked_at(uint64_t p_pcb_flags, uint64_t flags)
+{
+    return copy_to_kernel(p_pcb_flags, &(const uint64_t){flags & ~PCB_DBREGS}, sizeof(uint64_t));
+}
+
+static inline int restore_dbgregs_state_checked(const uint64_t* dr, int had_dbregs)
+{
+    if(write_dbgregs_checked(dr))
+        return 1;
+    if(!had_dbregs && clear_pcb_dbregs_checked())
+        return 1;
+    return 0;
+}
+
+static inline int restore_dbgregs_state_checked_at(uint64_t p_pcb_flags, uint64_t flags, const uint64_t* dr, int had_dbregs)
+{
+    if(write_dbgregs_checked(dr))
+        return 1;
+    if(!had_dbregs && clear_pcb_dbregs_checked_at(p_pcb_flags, flags))
+        return 1;
+    return 0;
 }


### PR DESCRIPTION
## Summary
- add checked helpers for stack and kernel copy operations
- make FPU entry and rollback failures explicit
- tighten NPDRM and fake-key error handling
- fix fake-key publication race handling
- normalize a few low-level firmware/version and pcb field checks

## Notes
- this aims to preserve success-path behavior while making failure paths explicit
- follow-up caching and performance work stays in separate PRs
