### PR TITLE
ps5-kstuff: streamline loader startup and allocation

### DIFF
--- a/ps5-kstuff-ldr/main.c
+++ b/ps5-kstuff-ldr/main.c
@@ -70,6 +70,10 @@ static int mount_nullfs(const char* src, const char* dst) {
     return nmount(iov, IOVEC_SIZE(iov), 0);
 }
 
+static int automount_disabled(void) {
+    return access("/data/.kstuff_noautomount", F_OK) == 0;
+}
+
 static int bind_mount_title(const char* title_id, const char* src) {
     char dst[PATH_MAX];
     struct stat st;
@@ -254,6 +258,11 @@ int main(void) {
     if(*args->payloadout == 0) {
         puts("patching app.db");
         *args->payloadout = patch_app_db();
+    }
+
+    if (automount_disabled()) {
+        klog_printf("Automount disabled by /data/.kstuff_noautomount\n");
+        return 0;
     }
 
     klog_printf("Remounting /system_ex and mounting titles...\n");

--- a/ps5-kstuff/kelf.asm
+++ b/ps5-kstuff/kelf.asm
@@ -344,7 +344,9 @@ times iret_rcx-iret_rdx-8 db 0
 dq justreturn_bak
 times iret_r8-iret_rcx-8 db 0
 dq return_wrmsr_gsbase+4
-times iret_rip-iret_r8-8 db 0
+times iret_r9-iret_r8-8 db 0
+dq restore_cr3
+times iret_rip-iret_r9-8 db 0
 dq doreti_iret
 dq 0x20
 dq 2

--- a/ps5-kstuff/main.c
+++ b/ps5-kstuff/main.c
@@ -2,11 +2,9 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
-#include <sys/user.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdarg.h>
-#include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -372,37 +370,17 @@ void build_uelf_cr3(uint64_t uelf_cr3, void* uelf_base[2], uint64_t uelf_virt_ba
 
 int find_proc(const char* name)
 {
-    enum { PROC_LIST_RETRIES = 4, PROC_LIST_SLACK = 16 };
-    int key[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
-    for(int attempt = 0; attempt < PROC_LIST_RETRIES; attempt++)
+    for(int pid = 1; pid < 1024; pid++)
     {
-        size_t sz = 0;
-        if(sysctl(key, 4, 0, &sz, 0, 0))
-            return -1;
-        if(sz > (size_t)-1 - PROC_LIST_SLACK * sizeof(struct kinfo_proc))
-            return -1;
-        size_t alloc_sz = sz + PROC_LIST_SLACK * sizeof(struct kinfo_proc);
-        struct kinfo_proc* proc_list = mmap(0, alloc_sz, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
-        if(proc_list == MAP_FAILED)
-            return -1;
-        size_t out_sz = alloc_sz;
-        if(!sysctl(key, 4, proc_list, &out_sz, 0, 0))
-        {
-            size_t count = out_sz / sizeof(*proc_list);
-            for(size_t i = 0; i < count; i++)
-                if(!strcmp(proc_list[i].ki_comm, name))
-                {
-                    int pid = proc_list[i].ki_pid;
-                    munmap(proc_list, alloc_sz);
-                    return pid;
-                }
-            munmap(proc_list, alloc_sz);
-            return -1;
-        }
-        int saved_errno = errno;
-        munmap(proc_list, alloc_sz);
-        if(saved_errno != ENOMEM)
-            return -1;
+        size_t sz = 1096;
+        int key[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+        char buf[1097] = {0};
+        sysctl(key, 4, buf, &sz, 0, 0);
+        const char* a = buf + 447;
+        const char* b = name;
+        while(*a && *a++ == *b++);
+        if(!*a && !*b)
+            return pid;
     }
     return -1;
 }

--- a/ps5-kstuff/main.c
+++ b/ps5-kstuff/main.c
@@ -61,12 +61,34 @@ static void kpoke64(void* dst, uint64_t src)
     kmemcpy(dst, &src, 8);
 }
 
+enum { KZERO_CHUNK_SIZE = 1 << 16 };
+
+static void* get_zero_chunk(void)
+{
+    static char* zero_chunk;
+    if(!zero_chunk)
+    {
+        zero_chunk = mmap(0, KZERO_CHUNK_SIZE, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
+        if(zero_chunk == MAP_FAILED)
+            die();
+        if(mlock(zero_chunk, KZERO_CHUNK_SIZE))
+            die();
+    }
+    return zero_chunk;
+}
+
 static void kmemzero(void* dst, size_t sz)
 {
-    char* umem = mmap(0, sz, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
-    mlock(umem, sz);
-    kmemcpy(dst, umem, sz);
-    munmap(umem, sz);
+    const char* zero_chunk = get_zero_chunk();
+    while(sz)
+    {
+        size_t chunk = sz;
+        if(chunk > KZERO_CHUNK_SIZE)
+            chunk = KZERO_CHUNK_SIZE;
+        kmemcpy(dst, zero_chunk, chunk);
+        dst = (char*)dst + chunk;
+        sz -= chunk;
+    }
 }
 
 static int strcmp(const char* a, const char* b)

--- a/ps5-kstuff/main.c
+++ b/ps5-kstuff/main.c
@@ -82,9 +82,43 @@ static int strcmp(const char* a, const char* b)
 #define kmalloc my_kmalloc
 
 static uint64_t mem_blocks[8];
+enum { KMALLOC_CHUNK_SIZE = 1 << 22 };
+
+static size_t align_up(size_t value, size_t alignment)
+{
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+static void kmalloc_add_block(size_t min_size)
+{
+    size_t block_size = align_up(min_size, 4096);
+    if(block_size < KMALLOC_CHUNK_SIZE)
+        block_size = KMALLOC_CHUNK_SIZE;
+    for(int i = 0; i < 8; i += 2)
+    {
+        if(mem_blocks[i] || mem_blocks[i+1])
+            continue;
+        while(!mem_blocks[i])
+            mem_blocks[i] = r0gdb_kmalloc(block_size);
+        mem_blocks[i+1] = mem_blocks[i] + block_size;
+        return;
+    }
+    die();
+}
 
 static void* kmalloc(size_t sz)
 {
+    sz = align_up(sz, 16);
+    for(int i = 0; i < 8; i += 2)
+    {
+        if(mem_blocks[i] + sz <= mem_blocks[i+1])
+        {
+            uint64_t ans = mem_blocks[i];
+            mem_blocks[i] += sz;
+            return (void*)ans;
+        }
+    }
+    kmalloc_add_block(sz);
     for(int i = 0; i < 8; i += 2)
     {
         if(mem_blocks[i] + sz <= mem_blocks[i+1])
@@ -729,12 +763,7 @@ int main(void* ds, int a, int b, uintptr_t c, uintptr_t d)
     gdb_remote_syscall("write", 3, 0, (uintptr_t)1, (uintptr_t)"allocating kernel memory... ", (uintptr_t)28);
     for(int i = 0; i < 0x300; i += 2)
         r0gdb_kmalloc(0x100);
-    for(int i = 0; i < 2; i += 2)
-    {
-        while(!mem_blocks[i])
-            mem_blocks[i] = r0gdb_kmalloc(1<<23);
-        mem_blocks[i+1] = (mem_blocks[i] ? mem_blocks[i] + (1<<23) : 0);
-    }
+    kmalloc_add_block(KMALLOC_CHUNK_SIZE);
     gdb_remote_syscall("write", 3, 0, (uintptr_t)1, (uintptr_t)"done\n", (uintptr_t)5);
     uint64_t comparison_table_base = (uint64_t)kmalloc(131072);
     uint64_t comparison_table = ((comparison_table_base - 1) | 65535) + 1;

--- a/ps5-kstuff/main.c
+++ b/ps5-kstuff/main.c
@@ -2,9 +2,11 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
+#include <sys/user.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdarg.h>
+#include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -265,6 +267,28 @@ uint64_t virt2phys(uintptr_t addr, uint64_t* phys_limit, uint64_t dmap, uint64_t
     //unreachable
 }
 
+static uint64_t virt2phys_or_die(uintptr_t addr, uint64_t* phys_limit, uint64_t dmap, uint64_t pml)
+{
+    uint64_t phys = virt2phys(addr, phys_limit, dmap, pml);
+    if(phys == (uint64_t)-1)
+        die();
+    return phys;
+}
+
+static void build_uelf_pml1(uint64_t pml1_virt, uint64_t user_start, uint64_t user_end, uint64_t dmap, uint64_t cr3)
+{
+    uint64_t phys = 0;
+    uint64_t phys_end = 0;
+    uint64_t vaddr = user_start;
+    for(uint64_t i = 0; vaddr < user_end; i++, vaddr += 4096)
+    {
+        if(vaddr >= phys_end)
+            phys = virt2phys_or_die(vaddr, &phys_end, dmap, cr3);
+        copyin(pml1_virt+8*i, &(uint64_t[1]){phys | 7}, 8);
+        phys += 4096;
+    }
+}
+
 uint64_t kernel_get_proc(uint64_t pid)
 {
     uint64_t proc = kread8(offsets.allproc);
@@ -320,11 +344,9 @@ uint64_t find_empty_pml4_index(int idx)
             return i;
 }
 
-void build_uelf_cr3(uint64_t uelf_cr3, void* uelf_base[2], uint64_t uelf_virt_base, uint64_t dmap_virt_base)
+void build_uelf_cr3(uint64_t uelf_cr3, void* uelf_base[2], uint64_t uelf_virt_base, uint64_t dmap_virt_base, uint64_t dmap, uint64_t cr3)
 {
     static char zeros[4096];
-    uint64_t dmap = get_dmap_base();
-    uint64_t cr3 = r0gdb_read_cr3();
     uint64_t user_start = (uint64_t)uelf_base[0];
     uint64_t user_end = (uint64_t)uelf_base[1];
     if((uelf_virt_base & 0x1fffff) || (dmap_virt_base & ((1ull << 39) - 1)) || user_end - user_start > 0x200000)
@@ -334,34 +356,53 @@ void build_uelf_cr3(uint64_t uelf_cr3, void* uelf_base[2], uint64_t uelf_virt_ba
     kmemcpy((void*)(pml4_virt+2048), (void*)(dmap+cr3+2048), 2048);
     uint64_t pml3_virt = uelf_cr3 + 4096;
     uint64_t pml3_dmap = uelf_cr3 + 16384; //user-accessible direct mapping of physical memory
-    copyin(pml4_virt + 8 * ((uelf_virt_base >> 39) & 511), &(uint64_t[1]){virt2phys(pml3_virt,0,0,0) | 7}, 8);
-    copyin(pml4_virt + 8 * ((dmap_virt_base >> 39) & 511), &(uint64_t[1]){virt2phys(pml3_dmap,0,0,0) | 7}, 8);
+    copyin(pml4_virt + 8 * ((uelf_virt_base >> 39) & 511), &(uint64_t[1]){virt2phys_or_die(pml3_virt, 0, dmap, cr3) | 7}, 8);
+    copyin(pml4_virt + 8 * ((dmap_virt_base >> 39) & 511), &(uint64_t[1]){virt2phys_or_die(pml3_dmap, 0, dmap, cr3) | 7}, 8);
     copyin(pml3_virt, zeros, 4096);
     uint64_t pml2_virt = uelf_cr3 + 8192;
-    copyin(pml3_virt + 8 * ((uelf_virt_base >> 30) & 511), &(uint64_t[1]){virt2phys(pml2_virt,0,0,0) | 7}, 8);
+    copyin(pml3_virt + 8 * ((uelf_virt_base >> 30) & 511), &(uint64_t[1]){virt2phys_or_die(pml2_virt, 0, dmap, cr3) | 7}, 8);
     copyin(pml2_virt, zeros, 4096);
     uint64_t pml1_virt = uelf_cr3 + 12288;
-    copyin(pml2_virt + 8 * ((uelf_virt_base >> 21) & 511), &(uint64_t[1]){virt2phys(pml1_virt,0,0,0) | 7}, 8);
+    copyin(pml2_virt + 8 * ((uelf_virt_base >> 21) & 511), &(uint64_t[1]){virt2phys_or_die(pml1_virt, 0, dmap, cr3) | 7}, 8);
     copyin(pml1_virt, zeros, 4096);
-    for(uint64_t i = 0; i * 4096 + user_start < user_end; i++)
-        copyin(pml1_virt+8*i, &(uint64_t[1]){virt2phys(i*4096+user_start,0,0,0) | 7}, 8);
+    build_uelf_pml1(pml1_virt, user_start, user_end, dmap, cr3);
     for(uint64_t i = 0; i < 512; i++)
         copyin(pml3_dmap+8*i, &(uint64_t[1]){(i<<30) | 135}, 8);
 }
 
 int find_proc(const char* name)
 {
-    for(int pid = 1; pid < 1024; pid++)
+    enum { PROC_LIST_RETRIES = 4, PROC_LIST_SLACK = 16 };
+    int key[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
+    for(int attempt = 0; attempt < PROC_LIST_RETRIES; attempt++)
     {
-        size_t sz = 1096;
-        int key[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
-        char buf[1097] = {0};
-        sysctl(key, 4, buf, &sz, 0, 0);
-        const char* a = buf + 447;
-        const char* b = name;
-        while(*a && *a++ == *b++);
-        if(!*a && !*b)
-            return pid;
+        size_t sz = 0;
+        if(sysctl(key, 4, 0, &sz, 0, 0))
+            return -1;
+        if(sz > (size_t)-1 - PROC_LIST_SLACK * sizeof(struct kinfo_proc))
+            return -1;
+        size_t alloc_sz = sz + PROC_LIST_SLACK * sizeof(struct kinfo_proc);
+        struct kinfo_proc* proc_list = mmap(0, alloc_sz, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0);
+        if(proc_list == MAP_FAILED)
+            return -1;
+        size_t out_sz = alloc_sz;
+        if(!sysctl(key, 4, proc_list, &out_sz, 0, 0))
+        {
+            size_t count = out_sz / sizeof(*proc_list);
+            for(size_t i = 0; i < count; i++)
+                if(!strcmp(proc_list[i].ki_comm, name))
+                {
+                    int pid = proc_list[i].ki_pid;
+                    munmap(proc_list, alloc_sz);
+                    return pid;
+                }
+            munmap(proc_list, alloc_sz);
+            return -1;
+        }
+        int saved_errno = errno;
+        munmap(proc_list, alloc_sz);
+        if(saved_errno != ENOMEM)
+            return -1;
     }
     return -1;
 }
@@ -732,9 +773,11 @@ int main(void* ds, int a, int b, uintptr_t c, uintptr_t d)
     else
         shared_area = comparison_table + 65536;
     kmemzero((void*)shared_area, 4096);
+    uint64_t kernel_dmap = get_dmap_base();
+    uint64_t kernel_cr3 = r0gdb_read_cr3();
     uint64_t uelf_virt_base = (find_empty_pml4_index(0) << 39) | (-1ull << 48);
     uint64_t dmem_virt_base = (find_empty_pml4_index(1) << 39) | (-1ull << 48);
-    shared_area = virt2phys(shared_area,0,0,0) + dmem_virt_base;
+    shared_area = virt2phys_or_die(shared_area, 0, kernel_dmap, kernel_cr3) + dmem_virt_base;
 
     volatile int zero = 0; //hack to force runtime calculation of string pointers
     const char* symbols[] = {
@@ -821,12 +864,12 @@ int main(void* ds, int a, int b, uintptr_t c, uintptr_t d)
         uintptr_t uelf_cr3 = (uintptr_t)kmalloc(24576);
         uelf_cr3 = ((uelf_cr3 + 4095) | 4095) - 4095;
         uelf_cr3s[cpu] = uelf_cr3;
-        values[uelf_cr3_idx] = virt2phys(uelf_cr3,0,0,0);
+        values[uelf_cr3_idx] = virt2phys_or_die(uelf_cr3, 0, kernel_dmap, kernel_cr3);
         values[uelf_entry_idx] = (uintptr_t)uelf_entry - (uintptr_t)uelf_base[0] + uelf_virt_base;
         void* entry = 0;
         void* base[2] = {0};
         char* kelf = load_kelf(kek, symbols, values, base, &entry, 0);
-        build_uelf_cr3(uelf_cr3, uelf_base, uelf_virt_base, dmem_virt_base);
+        build_uelf_cr3(uelf_cr3, uelf_base, uelf_virt_base, dmem_virt_base, kernel_dmap, kernel_cr3);
         uelf_bases[cpu] = (uintptr_t)uelf;
         kelf_bases[cpu] = (uint64_t)kelf;
         kelf_entries[cpu] = (uint64_t)entry;


### PR DESCRIPTION
## Summary
- optimize early startup setup
- reuse zero buffers during kernel loads
- allocate the required module memory size automatically
- make automatic mounting optional

## Notes
- this PR is limited to loader/startup behavior
- unrelated crypto and uelf changes are kept out of it
