### PR TITLE
Build, CI, and cleanup updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,44 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Checkout pacbrew-repo
+      uses: actions/checkout@v4
+      with:
+        repository: EchoStretch/pacbrew-repo
+        path: pacbrew-repo
+
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install build-essential clang-18 lld-18 xxd yasm nasm
+        sudo apt install -y \
+          autoconf \
+          automake \
+          build-essential \
+          clang-18 \
+          curl \
+          git \
+          libarchive-tools \
+          libtool \
+          lld-18 \
+          makepkg \
+          meson \
+          nasm \
+          pacman-package-manager \
+          pkg-config \
+          xxd \
+          yasm
 
-    - name: Install toolchain
+    - name: Build PS5 payload SDK
+      working-directory: pacbrew-repo/sdk
       run: |
-        wget https://github.com/ps5-payload-dev/pacbrew-repo/releases/latest/download/ps5-payload-dev.tar.gz
-        sudo tar xf ps5-payload-dev.tar.gz -C /
+        makepkg -c -f
+        sudo pacman --noconfirm -U ./ps5-payload-*.pkg.tar.gz
+
+    - name: Build PS5 sqlite package
+      working-directory: pacbrew-repo/sqlite
+      run: |
+        makepkg -c -f
+        sudo pacman --noconfirm -U ./ps5-payload-*.pkg.tar.gz
 
     - name: Build Payload
       run: |

--- a/prosper0gdb/Makefile
+++ b/prosper0gdb/Makefile
@@ -1,19 +1,22 @@
+PROSPER0GDB_OPT ?= -O0
+PAYLOAD_OPT ?= -O0
+
 all: payload.bin prosper0gdb.o
 
 clean:
 	rm -f payload.elf payload.bin r0run.o prosper0gdb.o
 
 ../lib/lib-elf-ps5.a:
-	cd ../lib; make
+	cd ../lib; $(MAKE)
 
 r0run.o: r0run.asm
 	yasm -f elf64 -g dwarf2 r0run.asm -o r0run.o
 
 prosper0gdb.o: r0gdb.c r0run.o offsets.c offsets.h offsets/offset_list.txt
-	gcc -O0 -g -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -r -Wl,--unique='*' -ffunction-sections -fdata-sections $(EXTRA_CFLAGS) -DPS5KEK r0gdb.c r0run.o offsets.c -o prosper0gdb.o -fPIE -ffreestanding -fno-unwind-tables -fno-asynchronous-unwind-tables
+	gcc $(PROSPER0GDB_OPT) -g -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -r -Wl,--unique='*' -ffunction-sections -fdata-sections $(EXTRA_CFLAGS) -DPS5KEK r0gdb.c r0run.o offsets.c -o prosper0gdb.o -fPIE -ffreestanding -fno-unwind-tables -fno-asynchronous-unwind-tables
 
 payload.elf: ../lib/lib-elf-ps5.a main.c prosper0gdb.o dbg.c 
-	gcc -O0 -g -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -static ../lib/lib-elf-ps5.a $(EXTRA_CFLAGS) main.c prosper0gdb.o -DPS5KEK dbg.c -o payload.elf -fPIE -ffreestanding -no-pie -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384
+	gcc $(PAYLOAD_OPT) -g -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -static ../lib/lib-elf-ps5.a $(EXTRA_CFLAGS) main.c prosper0gdb.o -DPS5KEK dbg.c -o payload.elf -fPIE -ffreestanding -no-pie -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384
 
 payload.bin: payload.elf
 	objcopy payload.elf --only-section .text --only-section .data --only-section .bss --only-section .rodata -O binary payload.bin

--- a/ps5-kstuff-ldr/Makefile
+++ b/ps5-kstuff-ldr/Makefile
@@ -1,3 +1,5 @@
+LOADER_OPT ?= -O2
+
 #   Copyright (C) 2025 John Törnblom
 #
 # This file is free software; you can redistribute it and/or modify it
@@ -23,16 +25,18 @@ else
     $(error PS5_PAYLOAD_SDK is undefined)
 endif
 
-CFLAGS := -Wall -Werror
+CFLAGS += -Wall -Werror
 
 all: kstuff.elf
 
-payload_bin.c: ../ps5-kstuff/payload.bin 
-	make -C ../ps5-kstuff/
+../ps5-kstuff/payload.bin:
+	$(MAKE) -C ../ps5-kstuff/
+
+payload_bin.c: ../ps5-kstuff/payload.bin
 	xxd -i $^ > $@
 
 kstuff.elf: payload_bin.c main.c sqlite_triggers.c
-	$(CC) -o $@ main.c sqlite_triggers.c -lsqlite3
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LOADER_OPT) $(LDFLAGS) -o $@ main.c sqlite_triggers.c -lsqlite3
 	strip $@
 	
 clean:

--- a/ps5-kstuff-ldr/main.c
+++ b/ps5-kstuff-ldr/main.c
@@ -203,7 +203,6 @@ int main(void) {
 	sceKernelSetProcessName("kstuff.elf");
     Elf64_Ehdr *ehdr = (Elf64_Ehdr*)___ps5_kstuff_payload_bin;
     Elf64_Phdr *phdr = (Elf64_Phdr*)(___ps5_kstuff_payload_bin + ehdr->e_phoff);
-    Elf64_Shdr *shdr = (Elf64_Shdr*)(___ps5_kstuff_payload_bin + ehdr->e_shoff);
     void *base = (void*)0x0000000926100000;
     uintptr_t min_vaddr = -1;
     uintptr_t max_vaddr = 0;

--- a/ps5-kstuff-ldr/sqlite_triggers.c
+++ b/ps5-kstuff-ldr/sqlite_triggers.c
@@ -84,7 +84,6 @@ void run_stmt(sqlite3* db, const char* cmd, struct buf* buf)
 int patch_app_db(void)
 {
     struct buf buf = {};
-    char* errmsg;
     sqlite3* db;
     char* cmd;
 

--- a/ps5-kstuff/Makefile
+++ b/ps5-kstuff/Makefile
@@ -1,19 +1,24 @@
+PROSPER0GDB_OPT ?= -O0
+PAYLOAD_OPT ?= -O0
+UELF_OPT ?= -O3
+UELF_ARCH ?= -march=znver2 -mtune=znver2
+
 all: payload.bin
 
 clean:
 	rm -f payload.elf payload.bin  freebsd-loader kelf kelf.o structs.h structs.inc uelf/uelf uelf/uelf.bin uelf/crt.o
 
 ../lib/lib-elf-ps5.a:
-	cd ../lib; make
+	cd ../lib; $(MAKE)
 
 ../prosper0gdb/prosper0gdb.o:
-	cd ../prosper0gdb; make
+	cd ../prosper0gdb; $(MAKE) PROSPER0GDB_OPT="$(PROSPER0GDB_OPT)"
 
 structs.inc: structs-ps5.inc
 	cp structs-ps5.inc structs.inc
 
 payload.elf: ../lib/lib-elf-ps5.a ../prosper0gdb/prosper0gdb.o main.c kelf uelf/uelf.bin
-	gcc -O0 -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -static ../lib/lib-elf-ps5.a ../prosper0gdb/prosper0gdb.o $(EXTRA_CFLAGS) main.c -DPS5KEK ../prosper0gdb/dbg.c -Wl,-gc-sections -o payload.elf -fPIE -ffreestanding -no-pie -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384
+	gcc $(PAYLOAD_OPT) -isystem ../freebsd-headers -nostdinc -nostdlib -fno-stack-protector -static ../lib/lib-elf-ps5.a ../prosper0gdb/prosper0gdb.o $(EXTRA_CFLAGS) main.c -DPS5KEK ../prosper0gdb/dbg.c -Wl,-gc-sections -o payload.elf -fPIE -ffreestanding -no-pie -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384
 
 payloa%.bin: payloa%.elf
 	objcopy $< --only-section .text --only-section .data --only-section .bss --only-section .rodata -O binary $@
@@ -32,7 +37,7 @@ uelf/crt.o: uelf/crt.asm
 	yasm uelf/crt.asm -f elf64 -o uelf/crt.o
 
 uelf/uelf: uelf/*.c uelf/*.h structs.h uelf/crt.o BearSSL/build/libbearssl.a isa-l_crypto/bin/isa-l_crypto.a
-	gcc -Wl,-Bsymbolic -Wl,-gc-sections -ffunction-sections -fdata-sections -O3 -march=znver2 -mtune=znver2 -g -isystem ../freebsd-headers -isystem isa-l_crypto/include -nostdinc -nostdlib -mgeneral-regs-only -fno-stack-protector -fPIE -fPIC -shared -fvisibility=hidden -ffreestanding uelf/crt.o $(EXTRA_CFLAGS) uelf/*.c BearSSL/build/libbearssl.a isa-l_crypto/bin/isa-l_crypto.a -o uelf/uelf -Wl,-z,max-page-size=4096
+	gcc -Wl,-Bsymbolic -Wl,-gc-sections -ffunction-sections -fdata-sections $(UELF_OPT) $(UELF_ARCH) -g -isystem ../freebsd-headers -isystem isa-l_crypto/include -nostdinc -nostdlib -mgeneral-regs-only -fno-stack-protector -fPIE -fPIC -shared -fvisibility=hidden -ffreestanding uelf/crt.o $(EXTRA_CFLAGS) uelf/*.c BearSSL/build/libbearssl.a isa-l_crypto/bin/isa-l_crypto.a -o uelf/uelf -Wl,-z,max-page-size=4096
 
 uelf/uelf.bin: uelf/uelf
 	objcopy --strip-all $< $@

--- a/ps5-kstuff/uelf/npdrm.c
+++ b/ps5-kstuff/uelf/npdrm.c
@@ -187,14 +187,14 @@ int try_handle_npdrm_mailbox(uint64_t *regs, uint64_t lr)
 #else
     if (lr == (uint64_t)sceSblServiceMailbox_lr_npdrm_cmd_6)
 #endif
-    {
-        uint8_t decrypted_secret[sizeof(layout.rif.rifSecret)];
-        if (aes_cbc_128_decrypt_rif_debug_fpu_held(decrypted_secret, layout.rif.rifSecret,
-                                                   sizeof(layout.rif.rifSecret), layout.rif.rifIv))
         {
-            uelf_fpu_exit();
-            return 1;
-        }
+            uint8_t decrypted_secret[sizeof(layout.rif.rifSecret)];
+            if (aes_cbc_128_decrypt_rif_debug_fpu_held(decrypted_secret, layout.rif.rifSecret,
+                                                       sizeof(layout.rif.rifSecret), layout.rif.rifIv))
+            {
+                uelf_fpu_exit();
+                return 1;
+            }
 
         if (memcmp(contentid_hash + 16, decrypted_secret, 16) != 0)
         {
@@ -204,8 +204,7 @@ int try_handle_npdrm_mailbox(uint64_t *regs, uint64_t lr)
         }
 
         // copy both unk10 and unk20
-        if (copy_to_kernel(regs[RDX] + __builtin_offsetof(struct NpDrmCmd6, unk10),
-                           &decrypted_secret[0x70], 0x20))
+        if(copy_to_kernel(regs[RDX] + __builtin_offsetof(struct NpDrmCmd6, unk10), &decrypted_secret[0x70], 0x20))
         {
             uelf_fpu_exit();
             return 1;


### PR DESCRIPTION
- makes payload and loader optimization flags configurable in the project Makefiles
- updates GitHub Actions to build and install the PS5 payload SDK and sqlite package from `EchoStretch/pacbrew-repo`
- carries a small source-cleanup follow-up from the fork without the fork-only version string change