### PR TITLE
Add caller-only elevated capability profiles

### DIFF
--- a/include/kstuff.h
+++ b/include/kstuff.h
@@ -1,0 +1,104 @@
+#ifndef KSTUFF_H
+#define KSTUFF_H
+
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+
+#if !defined(__x86_64__)
+#error "kstuff client requests require x86-64"
+#endif
+
+#ifdef __cplusplus
+extern "C" int getpid(void);
+#else
+int getpid(void);
+#endif
+
+#define KSTUFF_PROBE_OP UINT32_C(0xffffffff)
+#define KSTUFF_SELF_ELEVATION_OP UINT32_C(7)
+#define KSTUFF_SELF_INSPECTION_OP UINT32_C(8)
+#define KSTUFF_SELF_ELEVATION_MAGIC UINT64_C(0x31564c4553355350)
+#define KSTUFF_SELF_ELEVATION_ABI_VERSION UINT64_C(1)
+#define KSTUFF_SELF_INSPECTION_AUTH_ID UINT64_C(1)
+
+typedef enum kstuff_profile {
+    KSTUFF_PROFILE_DATA_ACCESS = 1,
+    KSTUFF_PROFILE_PROCESS_MEMORY = 2,
+    KSTUFF_PROFILE_DEBUG = 3,
+} kstuff_profile_t;
+
+/*
+ * Client functions return zero on success or a positive errno value on
+ * failure. They do not set errno. A successful profile request changes only
+ * the calling process and remains active for that process's lifetime.
+ */
+static inline int kstuff_internal_request(uint32_t operation, uint64_t argument0,
+                                          uint64_t argument1, uint64_t argument2,
+                                          uint64_t* result)
+{
+    const uintptr_t syscall_entry = (uintptr_t)(void*)&getpid + 7;
+    uint64_t value = ((uint64_t)operation << 32) | UINT64_C(39);
+    register uint64_t argument3 __asm__("r10") = 0;
+    register uint64_t argument4 __asm__("r8") = 0;
+    register uint64_t argument5 __asm__("r9") = 0;
+    uint8_t failed = 0;
+
+    if(!result)
+        return EINVAL;
+
+    __asm__ volatile("call *%[entry]\n\tsetc %[failed]"
+                     : "+a"(value), [failed] "=qm"(failed), "+r"(argument3),
+                       "+r"(argument4), "+r"(argument5)
+                     : [entry] "r"(syscall_entry), "D"(argument0), "S"(argument1),
+                       "d"(argument2)
+                     : "rcx", "r11", "memory");
+
+    if(failed)
+        return value && value <= INT_MAX ? (int)value : EIO;
+    *result = value;
+    return 0;
+}
+
+/* Verify that the compatible kstuff request bridge is active. */
+static inline int kstuff_probe(void)
+{
+    uint64_t result;
+    int error = kstuff_internal_request(KSTUFF_PROBE_OP, 0, 0, 0, &result);
+    return error ? error : result ? EPROTO : 0;
+}
+
+/* Explicitly apply one fixed capability profile to the calling process. */
+static inline int kstuff_request_profile(kstuff_profile_t profile)
+{
+    uint64_t result;
+    int error;
+
+    if(profile != KSTUFF_PROFILE_DATA_ACCESS
+    && profile != KSTUFF_PROFILE_PROCESS_MEMORY
+    && profile != KSTUFF_PROFILE_DEBUG)
+        return EINVAL;
+
+    error = kstuff_internal_request(KSTUFF_SELF_ELEVATION_OP,
+                                    KSTUFF_SELF_ELEVATION_MAGIC,
+                                    KSTUFF_SELF_ELEVATION_ABI_VERSION,
+                                    (uint64_t)profile, &result);
+    return error ? error : result ? EPROTO : 0;
+}
+
+/* Read only the calling process's current kernel credential authority ID. */
+static inline int kstuff_get_authority_id(uint64_t* authority_id)
+{
+    int error;
+
+    if(!authority_id)
+        return EINVAL;
+    if((error = kstuff_probe()))
+        return error;
+    return kstuff_internal_request(KSTUFF_SELF_INSPECTION_OP,
+                                   KSTUFF_SELF_ELEVATION_MAGIC,
+                                   KSTUFF_SELF_ELEVATION_ABI_VERSION,
+                                   KSTUFF_SELF_INSPECTION_AUTH_ID, authority_id);
+}
+
+#endif

--- a/ps5-kstuff/Makefile
+++ b/ps5-kstuff/Makefile
@@ -3,6 +3,7 @@ PAYLOAD_OPT ?= -O0
 UELF_OPT ?= -O3
 UELF_ARCH ?= -march=znver2 -mtune=znver2
 KSTUFF_OBS ?= 0
+KSTUFF_SELF_ELEVATION ?= 1
 
 ALL_TARGETS := payload.bin
 BUILD_CONFIG := .build-config
@@ -25,6 +26,7 @@ FORCE:
 $(BUILD_CONFIG): FORCE
 	@tmp="$@.tmp"; \
 	printf 'KSTUFF_OBS=%s\n' "$(KSTUFF_OBS)" > "$$tmp"; \
+	printf 'KSTUFF_SELF_ELEVATION=%s\n' "$(KSTUFF_SELF_ELEVATION)" >> "$$tmp"; \
 	printf 'EXTRA_CFLAGS=%s\n' "$(EXTRA_CFLAGS)" >> "$$tmp"; \
 	printf 'PAYLOAD_OPT=%s\n' "$(PAYLOAD_OPT)" >> "$$tmp"; \
 	printf 'UELF_OPT=%s\n' "$(UELF_OPT)" >> "$$tmp"; \
@@ -60,7 +62,7 @@ uelf/crt.o: uelf/crt.asm
 	yasm uelf/crt.asm -f elf64 -o uelf/crt.o
 
 uelf/uelf: uelf/*.c uelf/*.h structs.h uelf/crt.o BearSSL/build/libbearssl.a isa-l_crypto/bin/isa-l_crypto.a $(BUILD_CONFIG)
-	gcc -Wl,-Bsymbolic -Wl,-gc-sections -ffunction-sections -fdata-sections $(UELF_OPT) $(UELF_ARCH) -g -isystem ../freebsd-headers -isystem isa-l_crypto/include -nostdinc -nostdlib -mgeneral-regs-only -fno-stack-protector -fPIE -fPIC -shared -fvisibility=hidden -ffreestanding uelf/crt.o $(EXTRA_CFLAGS) -DKSTUFF_OBS=$(KSTUFF_OBS) uelf/*.c BearSSL/build/libbearssl.a isa-l_crypto/bin/isa-l_crypto.a -o uelf/uelf -Wl,-z,max-page-size=4096
+	gcc -Wl,-Bsymbolic -Wl,-gc-sections -ffunction-sections -fdata-sections $(UELF_OPT) $(UELF_ARCH) -g -isystem ../freebsd-headers -isystem isa-l_crypto/include -nostdinc -nostdlib -mgeneral-regs-only -fno-stack-protector -fPIE -fPIC -shared -fvisibility=hidden -ffreestanding uelf/crt.o $(EXTRA_CFLAGS) -DKSTUFF_OBS=$(KSTUFF_OBS) -DKSTUFF_SELF_ELEVATION=$(KSTUFF_SELF_ELEVATION) uelf/*.c BearSSL/build/libbearssl.a isa-l_crypto/bin/isa-l_crypto.a -o uelf/uelf -Wl,-z,max-page-size=4096
 
 uelf/uelf.bin: uelf/uelf
 	objcopy --strip-all $< $@

--- a/ps5-kstuff/uelf/kekcall.c
+++ b/ps5-kstuff/uelf/kekcall.c
@@ -7,6 +7,9 @@
 #include "traps.h"
 #include "utils.h"
 #include "log.h"
+#if KSTUFF_SELF_ELEVATION
+#include "self_elevation.h"
+#endif
 
 extern char syscall_after[];
 extern char doreti_iret[];
@@ -87,6 +90,15 @@ int handle_kekcall(uint64_t* regs, uint64_t* args, uint32_t nr)
         return ENOSYS;
 #endif
     }
+#if KSTUFF_SELF_ELEVATION
+    else if(nr == KSTUFF_SELF_ELEVATION_OP)
+    {
+        int err = elevate_current_process(regs[RDI], args[RDI], args[RSI], args[RDX]);
+        if(!err)
+            args[RAX] = 0;
+        return err;
+    }
+#endif
    else if(nr == 0xffffffff)
     {
         args[RAX] = 0;

--- a/ps5-kstuff/uelf/kekcall.c
+++ b/ps5-kstuff/uelf/kekcall.c
@@ -98,6 +98,14 @@ int handle_kekcall(uint64_t* regs, uint64_t* args, uint32_t nr)
             args[RAX] = 0;
         return err;
     }
+    else if(nr == KSTUFF_SELF_INSPECTION_OP)
+    {
+        uint64_t value;
+        int err = inspect_current_process(regs[RDI], args[RDI], args[RSI], args[RDX], &value);
+        if(!err)
+            args[RAX] = value;
+        return err;
+    }
 #endif
    else if(nr == 0xffffffff)
     {

--- a/ps5-kstuff/uelf/kekcall.c
+++ b/ps5-kstuff/uelf/kekcall.c
@@ -93,10 +93,9 @@ int handle_kekcall(uint64_t* regs, uint64_t* args, uint32_t nr)
 #if KSTUFF_SELF_ELEVATION
     else if(nr == KSTUFF_SELF_ELEVATION_OP)
     {
-        int err = elevate_current_process(regs[RDI], args[RDI], args[RSI], args[RDX]);
-        if(!err)
-            args[RAX] = 0;
-        return err;
+        int err = begin_elevate_current_process(regs, regs[RDI], args[RDI],
+                                                args[RSI], args[RDX]);
+        return err ? err : ENOSYS;
     }
     else if(nr == KSTUFF_SELF_INSPECTION_OP)
     {
@@ -255,4 +254,10 @@ fail_remote_syscall:
         }
         regs[RIP] = stack_frame[13];
     }
+#if KSTUFF_SELF_ELEVATION
+    else if(trap == KSTUFF_SELF_ELEVATION_TRAP)
+    {
+        finish_elevate_current_process(regs);
+    }
+#endif
 }

--- a/ps5-kstuff/uelf/self_elevation.c
+++ b/ps5-kstuff/uelf/self_elevation.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2026 BlackBearReloaded
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "self_elevation.h"
+#include "utils.h"
+
+#if KSTUFF_SELF_ELEVATION
+
+#define SYSTEM_AUTH_ID UINT64_C(0x4801000000000013)
+#define MAX_PROCESS_WALK 4096
+
+extern char allproc[];
+
+struct kernel_layout
+{
+    uint16_t proc_ucred;
+    uint16_t proc_filedesc;
+    uint16_t proc_pid;
+    uint16_t ucred_uid;
+    uint16_t ucred_ruid;
+    uint16_t ucred_svuid;
+    uint16_t ucred_ngroups;
+    uint16_t ucred_rgid;
+    uint16_t ucred_svgid;
+    uint16_t ucred_prison;
+    uint16_t ucred_auth_id;
+    uint16_t ucred_caps;
+    uint16_t ucred_attributes;
+    uint16_t filedesc_root;
+    uint16_t filedesc_jail;
+};
+
+static const struct kernel_layout supported_layout = {
+    0x40, 0x48, 0xbc, 0x04, 0x08, 0x0c, 0x10, 0x14, 0x18,
+    0x30, 0x58, 0x60, 0x80, 0x10, 0x18,
+};
+
+struct process_state
+{
+    uint32_t uid;
+    uint32_t ruid;
+    uint32_t svuid;
+    uint32_t ngroups;
+    uint32_t rgid;
+    uint32_t svgid;
+    uint64_t prison;
+    uint64_t auth_id;
+    uint8_t caps[16];
+    uint8_t attributes[32];
+    uint64_t root_directory;
+    uint64_t jail_directory;
+};
+
+static int is_kernel_pointer(uint64_t pointer)
+{
+    return pointer && (pointer >> 48) == UINT64_C(0xffff);
+}
+
+static int firmware_supported(void)
+{
+    switch(FWVER)
+    {
+    case 0x0300:
+    case 0x0310:
+    case 0x0320:
+    case 0x0321:
+    case 0x0400:
+    case 0x0402:
+    case 0x0403:
+    case 0x0450:
+    case 0x0451:
+    case 0x0500:
+    case 0x0502:
+    case 0x0510:
+    case 0x0550:
+    case 0x0600:
+    case 0x0602:
+    case 0x0650:
+    case 0x0700:
+    case 0x0701:
+    case 0x0720:
+    case 0x0740:
+    case 0x0760:
+    case 0x0761:
+    case 0x0800:
+    case 0x0820:
+    case 0x0840:
+    case 0x0860:
+    case 0x0900:
+    case 0x0905:
+    case 0x0920:
+    case 0x0940:
+    case 0x0960:
+    case 0x1000:
+    case 0x1001:
+    case 0x1020:
+    case 0x1040:
+    case 0x1060:
+    case 0x1100:
+    case 0x1120:
+    case 0x1140:
+    case 0x1160:
+    case 0x1200:
+    case 0x1202:
+    case 0x1220:
+    case 0x1240:
+    case 0x1260:
+    case 0x1270:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static const struct kernel_layout* select_layout(void)
+{
+    return firmware_supported() ? &supported_layout : 0;
+}
+
+static int read_process_links(uint64_t process, const struct kernel_layout* layout,
+                              uint64_t* ucred, uint64_t* filedesc)
+{
+    if(!is_kernel_pointer(process)
+    || copy_u64_from_kernel(ucred, process + layout->proc_ucred)
+    || copy_u64_from_kernel(filedesc, process + layout->proc_filedesc)
+    || !is_kernel_pointer(*ucred)
+    || !is_kernel_pointer(*filedesc))
+        return EFAULT;
+    return 0;
+}
+
+static int find_process_one(const struct kernel_layout* layout, uint64_t* process_one)
+{
+    uint64_t process;
+    if(copy_u64_from_kernel(&process, (uint64_t)allproc))
+        return EFAULT;
+
+    for(unsigned int i = 0; process && i < MAX_PROCESS_WALK; i++)
+    {
+        uint32_t pid;
+        uint64_t next;
+        if(!is_kernel_pointer(process)
+        || copy_u32_from_kernel(&pid, process + layout->proc_pid))
+            return EFAULT;
+        if(pid == 1)
+        {
+            *process_one = process;
+            return 0;
+        }
+        if(copy_u64_from_kernel(&next, process))
+            return EFAULT;
+        process = next;
+    }
+    return ESRCH;
+}
+
+static int read_state(uint64_t ucred, uint64_t filedesc,
+                      const struct kernel_layout* layout, struct process_state* state)
+{
+    if(copy_u32_from_kernel(&state->uid, ucred + layout->ucred_uid)
+    || copy_u32_from_kernel(&state->ruid, ucred + layout->ucred_ruid)
+    || copy_u32_from_kernel(&state->svuid, ucred + layout->ucred_svuid)
+    || copy_u32_from_kernel(&state->ngroups, ucred + layout->ucred_ngroups)
+    || copy_u32_from_kernel(&state->rgid, ucred + layout->ucred_rgid)
+    || copy_u32_from_kernel(&state->svgid, ucred + layout->ucred_svgid)
+    || copy_u64_from_kernel(&state->prison, ucred + layout->ucred_prison)
+    || copy_u64_from_kernel(&state->auth_id, ucred + layout->ucred_auth_id)
+    || copy_from_kernel(state->caps, ucred + layout->ucred_caps, sizeof(state->caps))
+    || copy_from_kernel(state->attributes, ucred + layout->ucred_attributes,
+                        sizeof(state->attributes))
+    || copy_u64_from_kernel(&state->root_directory, filedesc + layout->filedesc_root)
+    || copy_u64_from_kernel(&state->jail_directory, filedesc + layout->filedesc_jail))
+        return EFAULT;
+    return 0;
+}
+
+static int write_state(uint64_t ucred, uint64_t filedesc,
+                       const struct kernel_layout* layout,
+                       const struct process_state* state)
+{
+    if(copy_u32_to_kernel(ucred + layout->ucred_uid, state->uid)
+    || copy_u32_to_kernel(ucred + layout->ucred_ruid, state->ruid)
+    || copy_u32_to_kernel(ucred + layout->ucred_svuid, state->svuid)
+    || copy_u32_to_kernel(ucred + layout->ucred_ngroups, state->ngroups)
+    || copy_u32_to_kernel(ucred + layout->ucred_rgid, state->rgid)
+    || copy_u32_to_kernel(ucred + layout->ucred_svgid, state->svgid)
+    || copy_u64_to_kernel(ucred + layout->ucred_prison, state->prison)
+    || copy_u64_to_kernel(ucred + layout->ucred_auth_id, state->auth_id)
+    || copy_to_kernel(ucred + layout->ucred_caps, state->caps, sizeof(state->caps))
+    || copy_to_kernel(ucred + layout->ucred_attributes, state->attributes,
+                      sizeof(state->attributes))
+    || copy_u64_to_kernel(filedesc + layout->filedesc_root, state->root_directory)
+    || copy_u64_to_kernel(filedesc + layout->filedesc_jail, state->jail_directory))
+        return EFAULT;
+    return 0;
+}
+
+static int states_equal(const struct process_state* left,
+                        const struct process_state* right)
+{
+    return left->uid == right->uid
+        && left->ruid == right->ruid
+        && left->svuid == right->svuid
+        && left->ngroups == right->ngroups
+        && left->rgid == right->rgid
+        && left->svgid == right->svgid
+        && left->prison == right->prison
+        && left->auth_id == right->auth_id
+        && !memcmp(left->caps, right->caps, sizeof(left->caps))
+        && !memcmp(left->attributes, right->attributes, sizeof(left->attributes))
+        && left->root_directory == right->root_directory
+        && left->jail_directory == right->jail_directory;
+}
+
+static int restore_state(uint64_t ucred, uint64_t filedesc,
+                         const struct kernel_layout* layout,
+                         const struct process_state* original)
+{
+    struct process_state restored;
+    if(write_state(ucred, filedesc, layout, original)
+    || read_state(ucred, filedesc, layout, &restored)
+    || !states_equal(&restored, original))
+        return EIO;
+    return 0;
+}
+
+int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
+                            uint64_t profile)
+{
+    const struct kernel_layout* layout;
+    struct process_state original;
+    struct process_state root;
+    struct process_state target;
+    struct process_state verified;
+    uint64_t current_process;
+    uint64_t current_ucred;
+    uint64_t current_filedesc;
+    uint64_t process_one;
+    uint64_t root_ucred;
+    uint64_t root_filedesc;
+    uint32_t current_pid;
+    int error;
+
+    if(magic != KSTUFF_SELF_ELEVATION_MAGIC
+    || version != KSTUFF_SELF_ELEVATION_ABI_VERSION
+    || profile != KSTUFF_SELF_ELEVATION_PROFILE_DATA_ACCESS)
+        return EINVAL;
+    if(!(layout = select_layout()))
+        return EPROTONOSUPPORT;
+    if(!is_kernel_pointer(thread)
+    || copy_u64_from_kernel(&current_process, thread + td_proc)
+    || read_process_links(current_process, layout, &current_ucred, &current_filedesc)
+    || copy_u32_from_kernel(&current_pid, current_process + layout->proc_pid)
+    || !current_pid)
+        return EFAULT;
+    if((error = find_process_one(layout, &process_one))
+    || (error = read_process_links(process_one, layout, &root_ucred, &root_filedesc))
+    || (error = read_state(current_ucred, current_filedesc, layout, &original))
+    || (error = read_state(root_ucred, root_filedesc, layout, &root)))
+        return error;
+    if(!is_kernel_pointer(root.prison) || !is_kernel_pointer(root.root_directory))
+        return EFAULT;
+
+    target = original;
+    target.uid = 0;
+    target.ruid = 0;
+    target.svuid = 0;
+    target.ngroups = 0;
+    target.rgid = 0;
+    target.svgid = 0;
+    target.prison = root.prison;
+    target.auth_id = SYSTEM_AUTH_ID;
+    memset(target.caps, 0xff, sizeof(target.caps));
+    target.attributes[3] |= 0x80;
+    target.root_directory = root.root_directory;
+    target.jail_directory = is_kernel_pointer(root.jail_directory)
+                          ? root.jail_directory : root.root_directory;
+
+    if(write_state(current_ucred, current_filedesc, layout, &target)
+    || read_state(current_ucred, current_filedesc, layout, &verified)
+    || !states_equal(&verified, &target))
+    {
+        error = restore_state(current_ucred, current_filedesc, layout, &original);
+        return error ? error : EFAULT;
+    }
+    return 0;
+}
+
+#endif

--- a/ps5-kstuff/uelf/self_elevation.c
+++ b/ps5-kstuff/uelf/self_elevation.c
@@ -271,9 +271,9 @@ int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
 
     if(magic != KSTUFF_SELF_ELEVATION_MAGIC
     || version != KSTUFF_SELF_ELEVATION_ABI_VERSION
-    || (profile != KSTUFF_SELF_ELEVATION_PROFILE_DATA_ACCESS
-     && profile != KSTUFF_SELF_ELEVATION_PROFILE_PROCESS_MEMORY
-     && profile != KSTUFF_SELF_ELEVATION_PROFILE_DEBUG))
+    || (profile != KSTUFF_PROFILE_DATA_ACCESS
+     && profile != KSTUFF_PROFILE_PROCESS_MEMORY
+     && profile != KSTUFF_PROFILE_DEBUG))
         return EINVAL;
     if(!(layout = select_layout()))
         return EPROTONOSUPPORT;
@@ -299,9 +299,9 @@ int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
     target.rgid = 0;
     target.svgid = 0;
     target.prison = root.prison;
-    if(profile == KSTUFF_SELF_ELEVATION_PROFILE_PROCESS_MEMORY)
+    if(profile == KSTUFF_PROFILE_PROCESS_MEMORY)
         target.auth_id = COREDUMP_AUTH_ID;
-    else if(profile == KSTUFF_SELF_ELEVATION_PROFILE_DEBUG)
+    else if(profile == KSTUFF_PROFILE_DEBUG)
         target.auth_id = DEBUG_AUTH_ID;
     else
         target.auth_id = SYSTEM_AUTH_ID;

--- a/ps5-kstuff/uelf/self_elevation.c
+++ b/ps5-kstuff/uelf/self_elevation.c
@@ -8,6 +8,8 @@
 #if KSTUFF_SELF_ELEVATION
 
 #define SYSTEM_AUTH_ID UINT64_C(0x4801000000000013)
+#define COREDUMP_AUTH_ID UINT64_C(0x4800000000000006)
+#define DEBUG_AUTH_ID UINT64_C(0x4800000000010003)
 #define MAX_PROCESS_WALK 4096
 
 extern char allproc[];
@@ -225,6 +227,31 @@ static int restore_state(uint64_t ucred, uint64_t filedesc,
     return 0;
 }
 
+int inspect_current_process(uint64_t thread, uint64_t magic, uint64_t version,
+                            uint64_t selector, uint64_t* value)
+{
+    const struct kernel_layout* layout;
+    struct process_state state;
+    uint64_t process;
+    uint64_t ucred;
+    uint64_t filedesc;
+
+    if(magic != KSTUFF_SELF_ELEVATION_MAGIC
+    || version != KSTUFF_SELF_ELEVATION_ABI_VERSION
+    || selector != KSTUFF_SELF_INSPECTION_AUTH_ID)
+        return EINVAL;
+    if(!(layout = select_layout()))
+        return EPROTONOSUPPORT;
+    if(!is_kernel_pointer(thread)
+    || copy_u64_from_kernel(&process, thread + td_proc)
+    || read_process_links(process, layout, &ucred, &filedesc)
+    || read_state(ucred, filedesc, layout, &state))
+        return EFAULT;
+
+    *value = state.auth_id;
+    return 0;
+}
+
 int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
                             uint64_t profile)
 {
@@ -244,7 +271,9 @@ int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
 
     if(magic != KSTUFF_SELF_ELEVATION_MAGIC
     || version != KSTUFF_SELF_ELEVATION_ABI_VERSION
-    || profile != KSTUFF_SELF_ELEVATION_PROFILE_DATA_ACCESS)
+    || (profile != KSTUFF_SELF_ELEVATION_PROFILE_DATA_ACCESS
+     && profile != KSTUFF_SELF_ELEVATION_PROFILE_PROCESS_MEMORY
+     && profile != KSTUFF_SELF_ELEVATION_PROFILE_DEBUG))
         return EINVAL;
     if(!(layout = select_layout()))
         return EPROTONOSUPPORT;
@@ -270,7 +299,12 @@ int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
     target.rgid = 0;
     target.svgid = 0;
     target.prison = root.prison;
-    target.auth_id = SYSTEM_AUTH_ID;
+    if(profile == KSTUFF_SELF_ELEVATION_PROFILE_PROCESS_MEMORY)
+        target.auth_id = COREDUMP_AUTH_ID;
+    else if(profile == KSTUFF_SELF_ELEVATION_PROFILE_DEBUG)
+        target.auth_id = DEBUG_AUTH_ID;
+    else
+        target.auth_id = SYSTEM_AUTH_ID;
     memset(target.caps, 0xff, sizeof(target.caps));
     target.attributes[3] |= 0x80;
     target.root_directory = root.root_directory;

--- a/ps5-kstuff/uelf/self_elevation.c
+++ b/ps5-kstuff/uelf/self_elevation.c
@@ -1,8 +1,3 @@
-/*
- * Copyright (C) 2026 BlackBearReloaded
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
-
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>

--- a/ps5-kstuff/uelf/self_elevation.c
+++ b/ps5-kstuff/uelf/self_elevation.c
@@ -1,8 +1,11 @@
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/syscall.h>
+#include <sys/sysent.h>
 
 #include "self_elevation.h"
+#include "traps.h"
 #include "utils.h"
 
 #if KSTUFF_SELF_ELEVATION
@@ -13,6 +16,8 @@
 #define MAX_PROCESS_WALK 4096
 
 extern char allproc[];
+extern char doreti_iret[];
+extern struct sysent sysents[];
 
 struct kernel_layout
 {
@@ -25,7 +30,6 @@ struct kernel_layout
     uint16_t ucred_ngroups;
     uint16_t ucred_rgid;
     uint16_t ucred_svgid;
-    uint16_t ucred_prison;
     uint16_t ucred_auth_id;
     uint16_t ucred_caps;
     uint16_t ucred_attributes;
@@ -35,23 +39,23 @@ struct kernel_layout
 
 static const struct kernel_layout supported_layout = {
     0x40, 0x48, 0xbc, 0x04, 0x08, 0x0c, 0x10, 0x14, 0x18,
-    0x30, 0x58, 0x60, 0x80, 0x10, 0x18,
+    0x58, 0x60, 0x80, 0x10, 0x18,
 };
 
-struct process_state
+enum elevation_frame
 {
-    uint32_t uid;
-    uint32_t ruid;
-    uint32_t svuid;
-    uint32_t ngroups;
-    uint32_t rgid;
-    uint32_t svgid;
-    uint64_t prison;
-    uint64_t auth_id;
-    uint8_t caps[16];
-    uint8_t attributes[32];
-    uint64_t root_directory;
-    uint64_t jail_directory;
+    ELEVATION_DORETI,
+    ELEVATION_TRAP,
+    ELEVATION_THREAD,
+    ELEVATION_PROCESS,
+    ELEVATION_OLD_UCRED,
+    ELEVATION_ROOT_UCRED,
+    ELEVATION_FILEDESC,
+    ELEVATION_PROFILE,
+    ELEVATION_ROOT_DIRECTORY,
+    ELEVATION_JAIL_DIRECTORY,
+    ELEVATION_EUID,
+    ELEVATION_FRAME_WORDS,
 };
 
 static int is_kernel_pointer(uint64_t pointer)
@@ -135,13 +139,14 @@ static int read_process_links(uint64_t process, const struct kernel_layout* layo
 static int find_process_one(const struct kernel_layout* layout, uint64_t* process_one)
 {
     uint64_t process;
+
     if(copy_u64_from_kernel(&process, (uint64_t)allproc))
         return EFAULT;
-
     for(unsigned int i = 0; process && i < MAX_PROCESS_WALK; i++)
     {
         uint32_t pid;
         uint64_t next;
+
         if(!is_kernel_pointer(process)
         || copy_u32_from_kernel(&pid, process + layout->proc_pid))
             return EFAULT;
@@ -157,73 +162,71 @@ static int find_process_one(const struct kernel_layout* layout, uint64_t* proces
     return ESRCH;
 }
 
-static int read_state(uint64_t ucred, uint64_t filedesc,
-                      const struct kernel_layout* layout, struct process_state* state)
+static uint64_t authority_for_profile(uint64_t profile)
 {
-    if(copy_u32_from_kernel(&state->uid, ucred + layout->ucred_uid)
-    || copy_u32_from_kernel(&state->ruid, ucred + layout->ucred_ruid)
-    || copy_u32_from_kernel(&state->svuid, ucred + layout->ucred_svuid)
-    || copy_u32_from_kernel(&state->ngroups, ucred + layout->ucred_ngroups)
-    || copy_u32_from_kernel(&state->rgid, ucred + layout->ucred_rgid)
-    || copy_u32_from_kernel(&state->svgid, ucred + layout->ucred_svgid)
-    || copy_u64_from_kernel(&state->prison, ucred + layout->ucred_prison)
-    || copy_u64_from_kernel(&state->auth_id, ucred + layout->ucred_auth_id)
-    || copy_from_kernel(state->caps, ucred + layout->ucred_caps, sizeof(state->caps))
-    || copy_from_kernel(state->attributes, ucred + layout->ucred_attributes,
-                        sizeof(state->attributes))
-    || copy_u64_from_kernel(&state->root_directory, filedesc + layout->filedesc_root)
-    || copy_u64_from_kernel(&state->jail_directory, filedesc + layout->filedesc_jail))
+    if(profile == KSTUFF_PROFILE_PROCESS_MEMORY)
+        return COREDUMP_AUTH_ID;
+    if(profile == KSTUFF_PROFILE_DEBUG)
+        return DEBUG_AUTH_ID;
+    return SYSTEM_AUTH_ID;
+}
+
+static int apply_profile(uint64_t ucred, uint64_t root_ucred,
+                         const struct kernel_layout* layout, uint64_t profile)
+{
+    uint32_t identity[6];
+    uint8_t caps[16];
+    uint8_t attributes[32];
+    uint64_t authority = authority_for_profile(profile);
+    uint64_t verified_authority;
+    uint32_t verified_identity[sizeof(identity) / sizeof(identity[0])];
+    uint8_t verified_caps[sizeof(caps)];
+    uint8_t verified_attributes[sizeof(attributes)];
+
+    if(copy_from_kernel(identity, root_ucred + layout->ucred_uid,
+                        sizeof(identity)))
+        return EFAULT;
+    memset(caps, 0xff, sizeof(caps));
+    if(copy_from_kernel(attributes, ucred + layout->ucred_attributes,
+                        sizeof(attributes)))
+        return EFAULT;
+    attributes[3] |= 0x80;
+    if(copy_to_kernel(ucred + layout->ucred_uid, identity, sizeof(identity))
+    || copy_u64_to_kernel(ucred + layout->ucred_auth_id, authority)
+    || copy_to_kernel(ucred + layout->ucred_caps, caps, sizeof(caps))
+    || copy_to_kernel(ucred + layout->ucred_attributes, attributes,
+                      sizeof(attributes))
+    || copy_from_kernel(verified_identity, ucred + layout->ucred_uid,
+                        sizeof(verified_identity))
+    || copy_u64_from_kernel(&verified_authority,
+                            ucred + layout->ucred_auth_id)
+    || copy_from_kernel(verified_caps, ucred + layout->ucred_caps,
+                        sizeof(verified_caps))
+    || copy_from_kernel(verified_attributes, ucred + layout->ucred_attributes,
+                        sizeof(verified_attributes))
+    || memcmp(verified_identity, identity, sizeof(identity))
+    || verified_authority != authority
+    || memcmp(verified_caps, caps, sizeof(caps))
+    || memcmp(verified_attributes, attributes, sizeof(attributes)))
         return EFAULT;
     return 0;
 }
 
-static int write_state(uint64_t ucred, uint64_t filedesc,
-                       const struct kernel_layout* layout,
-                       const struct process_state* state)
+static int apply_filesystem_root(uint64_t filedesc,
+                                 const struct kernel_layout* layout,
+                                 uint64_t root_directory,
+                                 uint64_t jail_directory)
 {
-    if(copy_u32_to_kernel(ucred + layout->ucred_uid, state->uid)
-    || copy_u32_to_kernel(ucred + layout->ucred_ruid, state->ruid)
-    || copy_u32_to_kernel(ucred + layout->ucred_svuid, state->svuid)
-    || copy_u32_to_kernel(ucred + layout->ucred_ngroups, state->ngroups)
-    || copy_u32_to_kernel(ucred + layout->ucred_rgid, state->rgid)
-    || copy_u32_to_kernel(ucred + layout->ucred_svgid, state->svgid)
-    || copy_u64_to_kernel(ucred + layout->ucred_prison, state->prison)
-    || copy_u64_to_kernel(ucred + layout->ucred_auth_id, state->auth_id)
-    || copy_to_kernel(ucred + layout->ucred_caps, state->caps, sizeof(state->caps))
-    || copy_to_kernel(ucred + layout->ucred_attributes, state->attributes,
-                      sizeof(state->attributes))
-    || copy_u64_to_kernel(filedesc + layout->filedesc_root, state->root_directory)
-    || copy_u64_to_kernel(filedesc + layout->filedesc_jail, state->jail_directory))
+    uint64_t verified_root;
+    uint64_t verified_jail;
+
+    if(copy_u64_to_kernel(filedesc + layout->filedesc_root, root_directory)
+    || copy_u64_to_kernel(filedesc + layout->filedesc_jail, jail_directory)
+    || copy_u64_from_kernel(&verified_root, filedesc + layout->filedesc_root)
+    || copy_u64_from_kernel(&verified_jail, filedesc + layout->filedesc_jail)
+    || verified_root != root_directory
+    || verified_jail != jail_directory)
         return EFAULT;
-    return 0;
-}
-
-static int states_equal(const struct process_state* left,
-                        const struct process_state* right)
-{
-    return left->uid == right->uid
-        && left->ruid == right->ruid
-        && left->svuid == right->svuid
-        && left->ngroups == right->ngroups
-        && left->rgid == right->rgid
-        && left->svgid == right->svgid
-        && left->prison == right->prison
-        && left->auth_id == right->auth_id
-        && !memcmp(left->caps, right->caps, sizeof(left->caps))
-        && !memcmp(left->attributes, right->attributes, sizeof(left->attributes))
-        && left->root_directory == right->root_directory
-        && left->jail_directory == right->jail_directory;
-}
-
-static int restore_state(uint64_t ucred, uint64_t filedesc,
-                         const struct kernel_layout* layout,
-                         const struct process_state* original)
-{
-    struct process_state restored;
-    if(write_state(ucred, filedesc, layout, original)
-    || read_state(ucred, filedesc, layout, &restored)
-    || !states_equal(&restored, original))
-        return EIO;
     return 0;
 }
 
@@ -231,7 +234,6 @@ int inspect_current_process(uint64_t thread, uint64_t magic, uint64_t version,
                             uint64_t selector, uint64_t* value)
 {
     const struct kernel_layout* layout;
-    struct process_state state;
     uint64_t process;
     uint64_t ucred;
     uint64_t filedesc;
@@ -245,28 +247,28 @@ int inspect_current_process(uint64_t thread, uint64_t magic, uint64_t version,
     if(!is_kernel_pointer(thread)
     || copy_u64_from_kernel(&process, thread + td_proc)
     || read_process_links(process, layout, &ucred, &filedesc)
-    || read_state(ucred, filedesc, layout, &state))
+    || copy_u64_from_kernel(value, ucred + layout->ucred_auth_id))
         return EFAULT;
-
-    *value = state.auth_id;
     return 0;
 }
 
-int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
-                            uint64_t profile)
+int begin_elevate_current_process(uint64_t* regs, uint64_t thread,
+                                  uint64_t magic, uint64_t version,
+                                  uint64_t profile)
 {
     const struct kernel_layout* layout;
-    struct process_state original;
-    struct process_state root;
-    struct process_state target;
-    struct process_state verified;
-    uint64_t current_process;
-    uint64_t current_ucred;
-    uint64_t current_filedesc;
+    uint64_t frame[ELEVATION_FRAME_WORDS] = {
+        [ELEVATION_DORETI] = (uint64_t)doreti_iret,
+        [ELEVATION_TRAP] = MKTRAP(TRAP_KEKCALL,
+                                  KSTUFF_SELF_ELEVATION_TRAP),
+        [ELEVATION_THREAD] = thread,
+        [ELEVATION_PROFILE] = profile,
+    };
     uint64_t process_one;
-    uint64_t root_ucred;
     uint64_t root_filedesc;
-    uint32_t current_pid;
+    uint64_t syscall_target;
+    uint32_t euid;
+    uint32_t pid;
     int error;
 
     if(magic != KSTUFF_SELF_ELEVATION_MAGIC
@@ -278,47 +280,75 @@ int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
     if(!(layout = select_layout()))
         return EPROTONOSUPPORT;
     if(!is_kernel_pointer(thread)
-    || copy_u64_from_kernel(&current_process, thread + td_proc)
-    || read_process_links(current_process, layout, &current_ucred, &current_filedesc)
-    || copy_u32_from_kernel(&current_pid, current_process + layout->proc_pid)
-    || !current_pid)
+    || copy_u64_from_kernel(&frame[ELEVATION_PROCESS], thread + td_proc)
+    || read_process_links(frame[ELEVATION_PROCESS], layout,
+                          &frame[ELEVATION_OLD_UCRED],
+                          &frame[ELEVATION_FILEDESC])
+    || copy_u32_from_kernel(&pid, frame[ELEVATION_PROCESS] + layout->proc_pid)
+    || !pid)
         return EFAULT;
     if((error = find_process_one(layout, &process_one))
-    || (error = read_process_links(process_one, layout, &root_ucred, &root_filedesc))
-    || (error = read_state(current_ucred, current_filedesc, layout, &original))
-    || (error = read_state(root_ucred, root_filedesc, layout, &root)))
-        return error;
-    if(!is_kernel_pointer(root.prison) || !is_kernel_pointer(root.root_directory))
+    || (error = read_process_links(process_one, layout,
+                                   &frame[ELEVATION_ROOT_UCRED],
+                                   &root_filedesc))
+    || copy_u64_from_kernel(&frame[ELEVATION_ROOT_DIRECTORY],
+                            root_filedesc + layout->filedesc_root)
+    || copy_u64_from_kernel(&frame[ELEVATION_JAIL_DIRECTORY],
+                            root_filedesc + layout->filedesc_jail)
+    || !is_kernel_pointer(frame[ELEVATION_ROOT_DIRECTORY]))
+        return error ? error : EFAULT;
+    if(!is_kernel_pointer(frame[ELEVATION_JAIL_DIRECTORY]))
+        frame[ELEVATION_JAIL_DIRECTORY] = frame[ELEVATION_ROOT_DIRECTORY];
+    /* Calling seteuid with the existing effective UID makes the kernel clone
+     * the credential and release the old reference through its native path. */
+    if(copy_u32_from_kernel(&euid,
+                            frame[ELEVATION_OLD_UCRED] + layout->ucred_uid))
+        return EFAULT;
+    frame[ELEVATION_EUID] = euid;
+    if(copy_u64_from_kernel(&syscall_target,
+                            (uint64_t)&sysents[SYS_seteuid].sy_call)
+    || !is_kernel_pointer(syscall_target)
+    || push_stack_checked(regs, frame, sizeof(frame)))
         return EFAULT;
 
-    target = original;
-    target.uid = 0;
-    target.ruid = 0;
-    target.svuid = 0;
-    target.ngroups = 0;
-    target.rgid = 0;
-    target.svgid = 0;
-    target.prison = root.prison;
-    if(profile == KSTUFF_PROFILE_PROCESS_MEMORY)
-        target.auth_id = COREDUMP_AUTH_ID;
-    else if(profile == KSTUFF_PROFILE_DEBUG)
-        target.auth_id = DEBUG_AUTH_ID;
-    else
-        target.auth_id = SYSTEM_AUTH_ID;
-    memset(target.caps, 0xff, sizeof(target.caps));
-    target.attributes[3] |= 0x80;
-    target.root_directory = root.root_directory;
-    target.jail_directory = is_kernel_pointer(root.jail_directory)
-                          ? root.jail_directory : root.root_directory;
-
-    if(write_state(current_ucred, current_filedesc, layout, &target)
-    || read_state(current_ucred, current_filedesc, layout, &verified)
-    || !states_equal(&verified, &target))
-    {
-        error = restore_state(current_ucred, current_filedesc, layout, &original);
-        return error ? error : EFAULT;
-    }
+    regs[RAX] = (uint64_t)&sysents[SYS_seteuid];
+    regs[RDI] = thread;
+    regs[RSI] = regs[RSP] + ELEVATION_EUID * sizeof(uint64_t);
+    regs[RIP] = syscall_target;
+    handle_syscall(regs, 0);
     return 0;
+}
+
+void finish_elevate_current_process(uint64_t* regs)
+{
+    const struct kernel_layout* layout = select_layout();
+    uint64_t frame[ELEVATION_FRAME_WORDS];
+    uint64_t new_ucred;
+    int error = (uint32_t)regs[RAX];
+
+    if(pop_stack_checked(regs, frame, sizeof(frame)))
+        return;
+    regs[RIP] = frame[ELEVATION_FRAME_WORDS - 1];
+    if(!layout)
+        error = EPROTONOSUPPORT;
+    else if(!error
+         && (copy_u64_from_kernel(&new_ucred,
+                                 frame[ELEVATION_PROCESS - 1]
+                                 + layout->proc_ucred)
+         || !is_kernel_pointer(new_ucred)
+         || new_ucred == frame[ELEVATION_OLD_UCRED - 1]
+         || apply_profile(new_ucred,
+                          frame[ELEVATION_ROOT_UCRED - 1], layout,
+                          frame[ELEVATION_PROFILE - 1])
+         || apply_filesystem_root(frame[ELEVATION_FILEDESC - 1], layout,
+                                  frame[ELEVATION_ROOT_DIRECTORY - 1],
+                                  frame[ELEVATION_JAIL_DIRECTORY - 1])))
+        error = EFAULT;
+
+    if(!error
+    && copy_u64_to_kernel(frame[ELEVATION_THREAD - 1] + td_retval, 0))
+        error = EFAULT;
+    regs[RAX] = error;
 }
 
 #endif

--- a/ps5-kstuff/uelf/self_elevation.h
+++ b/ps5-kstuff/uelf/self_elevation.h
@@ -3,9 +3,15 @@
 #include <stdint.h>
 
 #define KSTUFF_SELF_ELEVATION_OP 7u
+#define KSTUFF_SELF_INSPECTION_OP 8u
 #define KSTUFF_SELF_ELEVATION_MAGIC UINT64_C(0x31564c4553355350)
 #define KSTUFF_SELF_ELEVATION_ABI_VERSION UINT64_C(1)
 #define KSTUFF_SELF_ELEVATION_PROFILE_DATA_ACCESS UINT64_C(1)
+#define KSTUFF_SELF_ELEVATION_PROFILE_PROCESS_MEMORY UINT64_C(2)
+#define KSTUFF_SELF_ELEVATION_PROFILE_DEBUG UINT64_C(3)
+#define KSTUFF_SELF_INSPECTION_AUTH_ID UINT64_C(1)
 
 int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
                             uint64_t profile);
+int inspect_current_process(uint64_t thread, uint64_t magic, uint64_t version,
+                            uint64_t selector, uint64_t* value);

--- a/ps5-kstuff/uelf/self_elevation.h
+++ b/ps5-kstuff/uelf/self_elevation.h
@@ -1,8 +1,3 @@
-/*
- * Copyright (C) 2026 BlackBearReloaded
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
-
 #pragma once
 
 #include <stdint.h>

--- a/ps5-kstuff/uelf/self_elevation.h
+++ b/ps5-kstuff/uelf/self_elevation.h
@@ -1,15 +1,7 @@
 #pragma once
 
 #include <stdint.h>
-
-#define KSTUFF_SELF_ELEVATION_OP 7u
-#define KSTUFF_SELF_INSPECTION_OP 8u
-#define KSTUFF_SELF_ELEVATION_MAGIC UINT64_C(0x31564c4553355350)
-#define KSTUFF_SELF_ELEVATION_ABI_VERSION UINT64_C(1)
-#define KSTUFF_SELF_ELEVATION_PROFILE_DATA_ACCESS UINT64_C(1)
-#define KSTUFF_SELF_ELEVATION_PROFILE_PROCESS_MEMORY UINT64_C(2)
-#define KSTUFF_SELF_ELEVATION_PROFILE_DEBUG UINT64_C(3)
-#define KSTUFF_SELF_INSPECTION_AUTH_ID UINT64_C(1)
+#include "../../include/kstuff.h"
 
 int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
                             uint64_t profile);

--- a/ps5-kstuff/uelf/self_elevation.h
+++ b/ps5-kstuff/uelf/self_elevation.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 BlackBearReloaded
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define KSTUFF_SELF_ELEVATION_OP 7u
+#define KSTUFF_SELF_ELEVATION_MAGIC UINT64_C(0x31564c4553355350)
+#define KSTUFF_SELF_ELEVATION_ABI_VERSION UINT64_C(1)
+#define KSTUFF_SELF_ELEVATION_PROFILE_DATA_ACCESS UINT64_C(1)
+
+int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
+                            uint64_t profile);

--- a/ps5-kstuff/uelf/self_elevation.h
+++ b/ps5-kstuff/uelf/self_elevation.h
@@ -3,7 +3,11 @@
 #include <stdint.h>
 #include "../../include/kstuff.h"
 
-int elevate_current_process(uint64_t thread, uint64_t magic, uint64_t version,
-                            uint64_t profile);
+#define KSTUFF_SELF_ELEVATION_TRAP 5
+
+int begin_elevate_current_process(uint64_t* regs, uint64_t thread,
+                                  uint64_t magic, uint64_t version,
+                                  uint64_t profile);
+void finish_elevate_current_process(uint64_t* regs);
 int inspect_current_process(uint64_t thread, uint64_t magic, uint64_t version,
                             uint64_t selector, uint64_t* value);


### PR DESCRIPTION
Note: support is intentionally limited to firmware versions already represented by kstuff-lite's offset sets, through 12.70. Firmware 6.02 and 12.70 have been validated on hardware.

## Purpose

Native PS5 applications normally run inside a restricted sandbox. That is the correct default, but it prevents opt-in homebrew applications from performing legitimate operations such as managing files outside their application container, creating temporary mounts, or using privileged platform facilities. Without this proposal, an application needs a separate privileged payload or an application-specific out-of-process service. This PR instead adds a small, auditable, caller-only request interface to the already-running trusted kstuff component.

The feature is enabled by default and remains compile-time removable with `KSTUFF_SELF_ELEVATION=0`. Applications are never elevated automatically; the caller must issue a valid versioned request for one predefined profile.

## Design

The target is always derived from the current syscall thread's `td_proc`; a request cannot select another process. Operation 7 accepts only one of three fixed profiles, and operation 8 is a bounded read-only inspection that returns only the caller's current authority ID. Neither operation accepts a PID, kernel pointer, arbitrary authority ID, capability mask, or structure offset.

Requests use the existing `getppid` kekcall bridge and require an exact magic value and ABI version. Unknown operations, versions, selectors, profiles, and unsupported firmware fail closed. Kernel reads and writes are checked and the applied values are read back for verification.

## Credential strategy

The initial implementation edited the credential already referenced by the process. This revision no longer does that. It invokes the firmware's native `SYS_seteuid` handler with the caller's existing effective UID, which makes the kernel perform its normal credential copy-on-write operation, including allocation, process locking, `p_ucred` replacement, and release of the old credential reference. The completion trap verifies that `p_ucred` changed before applying a profile to the new caller-private credential.

The implementation does not copy or replace `cr_prison`. It changes only the new private credential's identity fields, authority ID, capability bytes, and required attribute bit. Filesystem roots are adjusted separately on the calling process's file-descriptor state after credential cloning succeeds.

## Request flow

```mermaid
sequenceDiagram
    participant App as Sandboxed native app
    participant API as kstuff.h
    participant Kstuff as kstuff-lite
    participant Kernel as Native kernel syscall path
    participant VFS as Normal kernel/VFS
    App->>API: kstuff_probe()
    API->>Kstuff: Versioned compatibility request
    Kstuff-->>API: Compatible or errno
    App->>API: kstuff_request_profile(DATA_ACCESS)
    API->>Kstuff: Versioned caller-only request
    Kstuff->>Kstuff: Derive caller from current thread
    Kstuff->>Kernel: SYS_seteuid(current effective UID)
    Kernel->>Kernel: Clone, lock, swap, and release ucred
    Kernel-->>Kstuff: Resume at completion trap
    Kstuff->>Kstuff: Verify private ucred and apply fixed profile
    Kstuff->>Kstuff: Update and verify caller filesystem roots
    Kstuff-->>App: Success or errno
    App->>VFS: sceKernelOpen("/data/example.txt")
    Note over App,VFS: Later operations use their normal syscall paths
    VFS-->>App: File descriptor or error
```

kstuff-lite changes the calling process state once; it does not proxy later file, network, mount, device, or debugging operations. Those calls continue through their normal kernel implementations, which evaluate the caller using the updated process state.

## Request ABI

| Operation | Selector | Result |
| --- | --- | --- |
| `7` | profile `1` | Elevate the caller for data, mount, and device access |
| `7` | profile `2` | Select the fixed coredump authority used by platform `mdbg` |
| `7` | profile `3` | Select the fixed debug authority used by platform ptrace |
| `8` | selector `1` | Return only the caller's current kernel credential authority ID |

## Native-application API

`include/kstuff.h` is the canonical header-only C interface and is directly usable from C++. It adds no library or runtime dependency and keeps operation numbers, magic values, ABI versions, profiles, selectors, validation, and syscall transport in one shared definition.

```c
#include <kstuff.h>

int error = kstuff_probe();
if (!error)
    error = kstuff_request_profile(KSTUFF_PROFILE_DATA_ACCESS);
```

The public calls are `kstuff_probe()`, `kstuff_request_profile()`, and `kstuff_get_authority_id()`. They return zero on success or a positive `errno` value on failure, reject invalid arguments locally, and do not mutate the caller's `errno`.

## Firmware handling

The credential layout is selected only for an explicit firmware whitelist covering versions already represented by kstuff-lite's supported offset sets. Unsupported firmware returns `EPROTONOSUPPORT`. No firmware value or credential offset is supplied by the application.

## Validation

| Check | Result |
| --- | --- |
| Firmware 6.02 | Fresh-reboot launch passed; the caller elevated, wrote and read `/data/hello-from-sandbox.txt`, and the console remained healthy |
| Firmware 12.70 | Fresh-reboot launch passed; the caller elevated, wrote and read `/data/hello-from-sandbox.txt`, and the console remained healthy |
| File contents | Exact bytes `hello from the sandboxed app\n`; SHA-256 `05bd42b8472a73be683feeaeba5b83367fee9669b970479e08500c3fa7cffd94` |
| Build configuration | Full build passed with `KSTUFF_SELF_ELEVATION=1` and `KSTUFF_SELF_ELEVATION=0` |
| Strict compile | `self_elevation.c` passed `-Wall -Wextra -Werror` |

The advanced profile tests documented by the companion example were completed during the earlier investigation. This table deliberately reports only the hardware checks repeated after switching to native credential copy-on-write.

## Code impact

The change is limited to five files: `include/kstuff.h`, the ps5-kstuff Makefile, the existing kekcall dispatcher, and the new `self_elevation.c` and `self_elevation.h` implementation files. It does not modify `prosper0gdb`, the loader protocol, console settings, or unrelated kstuff behavior.

## Scope boundary

This proposal does not add an exploit, generic kernel-memory interface, remote target selection, or network service. It provides fixed caller-only policy profiles for native applications running with a compatible kstuff build already active.

Focused C++ usage examples are available in [ps5-native-app-boilerplate PR #2](https://github.com/blackbearreloaded/ps5-native-app-boilerplate/pull/2).

## Beta artifact

The corrected beta build is available as [kstuff-self-escalation.elf](https://github.com/blackbearreloaded/kstuff-lite/releases/download/self-elevation-beta.2/kstuff-self-escalation.elf). It was built from commit `33ec81e5e086837f54644d519ed0a90b16d5c1f5` and has SHA-256 `88027ea317576cb0d087f455f3712972ef41484b158ba671838c1643a43cfa38`.
